### PR TITLE
bugfix:区分插件的探测结果与最终返回结果。解决在配置多个探测插件情况下，一个组件探测失败，一个组件无结果，导致无最终探测结果的情况

### DIFF
--- a/polaris-circuitbreaker/polaris-circuitbreaker-client/src/main/java/com/tencent/polaris/circuitbreak/client/task/InstancesDetectTask.java
+++ b/polaris-circuitbreaker/polaris-circuitbreaker-client/src/main/java/com/tencent/polaris/circuitbreak/client/task/InstancesDetectTask.java
@@ -138,10 +138,11 @@ public class InstancesDetectTask implements Runnable {
     private DetectResult detectInstance(Instance instance) throws PolarisException {
         DetectResult result = null;
         for (HealthChecker detector : extensions.getHealthCheckers()) {
-            result = detector.detectInstance(instance);
-            if (result == null) {
+            DetectResult pluginResult = detector.detectInstance(instance);
+            if (pluginResult == null) {
                 continue;
             }
+            result = pluginResult;
             if (result.getRetStatus() == RetStatus.RetSuccess) {
                 result.setDetectType(detector.getName());
                 return result;

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <properties>
         <!-- Project revision -->
-        <revision>1.9.5</revision>
+        <revision>1.9.6</revision>
 
         <timestamp>${maven.build.timestamp}</timestamp>
         <skip.maven.deploy>false</skip.maven.deploy>


### PR DESCRIPTION
如题所示