### PR TITLE
feat: polaris config should stop non-daemon threads when application …

### DIFF
--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileManager.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileManager.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+import com.tencent.polaris.api.control.Destroyable;
 import com.tencent.polaris.api.plugin.filter.ConfigFileFilterChain;
 import com.tencent.polaris.api.plugin.common.PluginTypes;
 import com.tencent.polaris.api.plugin.configuration.ConfigFileConnector;
@@ -77,6 +78,8 @@ public class ConfigFileManager {
         } catch (IOException e) {
             LOGGER.warn("config file persist handler init fail:" + e.getMessage(), e);
         }
+        //deal with the situation when the thread can't exit
+        registerDestroyHook(context);
     }
 
     public ConfigFile getConfigFile(ConfigFileMetadata configFileMetadata) {
@@ -161,4 +164,13 @@ public class ConfigFileManager {
         }
     }
 
+    private void registerDestroyHook(SDKContext context) {
+        context.registerDestroyHook(new Destroyable() {
+            @Override
+            protected void doDestroy() {
+                longPullService.doLongPullingDestroy();
+                persistentHandler.doDestroy();
+            }
+        });
+    }
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -42,6 +43,7 @@ import com.tencent.polaris.client.api.SDKContext;
 import com.tencent.polaris.client.util.NamedThreadFactory;
 import com.tencent.polaris.client.util.Utils;
 import com.tencent.polaris.api.plugin.configuration.ConfigFile;
+import com.tencent.polaris.api.utils.ThreadPoolUtils;
 import com.tencent.polaris.factory.util.FileUtils;
 import com.tencent.polaris.logging.LoggerFactory;
 import org.slf4j.Logger;
@@ -308,4 +310,7 @@ public class ConfigFilePersistentHandler {
 		}
 	}
 
+	protected void doDestroy() {
+		ThreadPoolUtils.waitAndStopThreadPools(new ExecutorService[]{persistExecutor});
+    }
 }


### PR DESCRIPTION
Polaris config creates multiple non-daemon threads that prevent JVM exit when the Spring application fails to start. Therefore, we should provide a destroy method to handle this situation.