### PR TITLE
fix: 修复熔断规则关闭后，没有清除缓存导致prometheus仍能采集到熔断，半熔断等状态数量

### DIFF
--- a/polaris-common/polaris-config/src/main/java/com/tencent/polaris/api/config/configuration/ConfigFileConfig.java
+++ b/polaris-common/polaris-config/src/main/java/com/tencent/polaris/api/config/configuration/ConfigFileConfig.java
@@ -1,6 +1,7 @@
 package com.tencent.polaris.api.config.configuration;
 
 import com.tencent.polaris.api.config.verify.Verifier;
+import com.tencent.polaris.factory.config.configuration.ConfigFilterConfigImpl;
 import com.tencent.polaris.factory.config.configuration.ConnectorConfigImpl;
 
 /**
@@ -22,7 +23,7 @@ public interface ConfigFileConfig extends Verifier {
      *
      * @return 过滤器配置对象
      */
-    ConfigFilterConfig getConfigFilterConfig();
+    ConfigFilterConfigImpl getConfigFilterConfig();
 
     /**
      * 值缓存的最大数量

--- a/polaris-common/polaris-config/src/main/java/com/tencent/polaris/api/config/provider/RegisterConfig.java
+++ b/polaris-common/polaris-config/src/main/java/com/tencent/polaris/api/config/provider/RegisterConfig.java
@@ -53,4 +53,11 @@ public interface RegisterConfig extends Verifier {
      * @return boolean
      */
     boolean isEnable();
+
+    /**
+     * If service contract reporting is enabled.
+     *
+     * @return boolean
+     */
+    boolean isReportServiceContractEnable();
 }

--- a/polaris-common/polaris-config/src/main/java/com/tencent/polaris/factory/config/configuration/ConfigFileConfigImpl.java
+++ b/polaris-common/polaris-config/src/main/java/com/tencent/polaris/factory/config/configuration/ConfigFileConfigImpl.java
@@ -2,7 +2,6 @@ package com.tencent.polaris.factory.config.configuration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tencent.polaris.api.config.configuration.ConfigFileConfig;
-import com.tencent.polaris.api.config.configuration.ConfigFilterConfig;
 import com.tencent.polaris.factory.util.ConfigUtils;
 
 /**
@@ -49,7 +48,7 @@ public class ConfigFileConfigImpl implements ConfigFileConfig {
     }
 
     @Override
-    public ConfigFilterConfig getConfigFilterConfig() {
+    public ConfigFilterConfigImpl getConfigFilterConfig() {
         return configFilter;
     }
 

--- a/polaris-common/polaris-config/src/main/java/com/tencent/polaris/factory/config/configuration/ConfigFilterConfigImpl.java
+++ b/polaris-common/polaris-config/src/main/java/com/tencent/polaris/factory/config/configuration/ConfigFilterConfigImpl.java
@@ -23,10 +23,10 @@ import com.tencent.polaris.api.config.configuration.CryptoConfig;
 import com.tencent.polaris.api.config.verify.Verifier;
 import com.tencent.polaris.api.exception.ErrorCode;
 import com.tencent.polaris.api.exception.PolarisException;
-import com.tencent.polaris.api.utils.MapUtils;
 import com.tencent.polaris.factory.config.plugin.PluginConfigImpl;
 import com.tencent.polaris.factory.util.ConfigUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,12 +43,17 @@ public class ConfigFilterConfigImpl extends PluginConfigImpl implements ConfigFi
     private Boolean enable;
 
     @JsonProperty
-    private List<String> chain;
+    private List<String> chain = new ArrayList<>();
 
     @Override
     public boolean isEnable() {
         return enable != null && enable;
     }
+
+    public void setEnable(Boolean enable) {
+        this.enable = enable;
+    }
+
 
     @Override
     public List<String> getChain() {
@@ -73,7 +78,8 @@ public class ConfigFilterConfigImpl extends PluginConfigImpl implements ConfigFi
         ConfigUtils.validateNull(chain, "ConfigFilterConfig Chain");
         ConfigUtils.validateNull(getPlugin(), "ConfigFilterConfig Plugin");
         if (getPlugin().size() != chain.size()) {
-            throw new PolarisException(ErrorCode.INVALID_CONFIG, "ConfigFilterConfig plugin config does not match chain");
+            throw new PolarisException(ErrorCode.INVALID_CONFIG, "ConfigFilterConfig plugin config does not match "
+                    + "chain");
         }
         chain.forEach(chain ->
                 ConfigUtils.validateNull(getPlugin().get(chain), "ConfigFilter plugin config for chain " + chain));

--- a/polaris-common/polaris-config/src/main/java/com/tencent/polaris/factory/config/provider/RegisterConfigImpl.java
+++ b/polaris-common/polaris-config/src/main/java/com/tencent/polaris/factory/config/provider/RegisterConfigImpl.java
@@ -40,6 +40,9 @@ public class RegisterConfigImpl implements RegisterConfig {
     @JsonProperty
     private Boolean enable;
 
+    @JsonProperty
+    private Boolean reportServiceContractEnable;
+
     @Override
     public String getNamespace() {
         return namespace;
@@ -77,6 +80,15 @@ public class RegisterConfigImpl implements RegisterConfig {
     }
 
     @Override
+    public boolean isReportServiceContractEnable() {
+        return reportServiceContractEnable;
+    }
+
+    public void setReportServiceContractEnable(Boolean reportServiceContractEnable) {
+        this.reportServiceContractEnable = reportServiceContractEnable;
+    }
+
+    @Override
     public void verify() {
         ConfigUtils.validateString(serverConnectorId,
                 "register.serverConnectorId or registers[?].serverConnectorId");
@@ -95,6 +107,9 @@ public class RegisterConfigImpl implements RegisterConfig {
             }
             if (null == enable) {
                 setEnable(registerConfig.isEnable());
+            }
+            if (null == reportServiceContractEnable) {
+                setReportServiceContractEnable(false);
             }
         }
     }

--- a/polaris-common/polaris-logging/src/main/java/com/tencent/polaris/logging/logback/LogbackPolarisLogging.java
+++ b/polaris-common/polaris-logging/src/main/java/com/tencent/polaris/logging/logback/LogbackPolarisLogging.java
@@ -18,7 +18,6 @@
 package com.tencent.polaris.logging.logback;
 
 import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.joran.JoranConfigurator;
 import ch.qos.logback.core.LogbackException;
 import com.tencent.polaris.logging.AbstractPolarisLogging;
 import org.slf4j.LoggerFactory;
@@ -42,9 +41,9 @@ public class LogbackPolarisLogging extends AbstractPolarisLogging {
             URL url = getResourceUrl(location);
             final String urlString = url.toString();
             if (urlString.endsWith("xml")) {
-                JoranConfigurator configurator = new JoranConfigurator();
+                PolarisJoranConfigurator configurator = new PolarisJoranConfigurator();
                 configurator.setContext(loggerContext);
-                configurator.doConfigure(url);
+                configurator.doPolarisConfigure(url);
             } else {
                 throw new LogbackException("Unexpected filename extension of file [" + url + "]. Should be"
                         + " either .groovy or .xml");

--- a/polaris-common/polaris-logging/src/main/java/com/tencent/polaris/logging/logback/PolarisJoranConfigurator.java
+++ b/polaris-common/polaris-logging/src/main/java/com/tencent/polaris/logging/logback/PolarisJoranConfigurator.java
@@ -1,0 +1,62 @@
+/*
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.logging.logback;
+
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.joran.event.SaxEvent;
+import ch.qos.logback.core.joran.spi.JoranException;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+
+/**
+ * @author Haotian Zhang
+ */
+public class PolarisJoranConfigurator extends JoranConfigurator {
+
+    @Override
+    public void registerSafeConfiguration(List<SaxEvent> eventList) {
+    }
+
+    public void doPolarisConfigure(URL url) throws JoranException {
+        InputStream in = null;
+        try {
+            URLConnection urlConnection = url.openConnection();
+            urlConnection.setUseCaches(false);
+            in = urlConnection.getInputStream();
+            doConfigure(in, url.toExternalForm());
+        } catch (IOException ioe) {
+            String errMsg = "Could not open URL [" + url + "].";
+            addError(errMsg, ioe);
+            throw new JoranException(errMsg, ioe);
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException ioe) {
+                    String errMsg = "Could not close [" + url + "] stream";
+                    addError(errMsg, ioe);
+                    throw new JoranException(errMsg, ioe);
+                }
+            }
+        }
+    }
+}

--- a/polaris-common/polaris-model/src/main/java/com/tencent/polaris/annonation/JustForTest.java
+++ b/polaris-common/polaris-model/src/main/java/com/tencent/polaris/annonation/JustForTest.java
@@ -15,7 +15,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.tencent.polaris.configuration.client;
+package com.tencent.polaris.annonation;
 
 /**
  * @author ledou 2022/3/8

--- a/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/CircuitBreakerStatus.java
+++ b/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/CircuitBreakerStatus.java
@@ -47,6 +47,11 @@ public class CircuitBreakerStatus {
      */
     private final FallbackInfo fallbackInfo;
 
+    /**
+     * 是否被销毁
+     */
+    private boolean isDestroy;
+
     public CircuitBreakerStatus(String circuitBreaker, Status status, long startTimeMs) {
         this(circuitBreaker, status, startTimeMs, null);
     }
@@ -72,6 +77,14 @@ public class CircuitBreakerStatus {
 
     public FallbackInfo getFallbackInfo() {
         return fallbackInfo;
+    }
+
+    public boolean isDestroy() {
+        return isDestroy;
+    }
+
+    public void setDestroy(boolean destroy) {
+        isDestroy = destroy;
     }
 
     /**

--- a/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/CircuitBreakerStatus.java
+++ b/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/CircuitBreakerStatus.java
@@ -133,7 +133,11 @@ public class CircuitBreakerStatus {
         /**
          * 熔断器打开状态，实例不提供服务
          */
-        OPEN
+        OPEN,
+        /**
+         * 熔断规则被销毁，实例可提供服务
+         */
+        DESTROY
     }
 
 

--- a/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/HalfOpenStatus.java
+++ b/polaris-common/polaris-model/src/main/java/com/tencent/polaris/api/pojo/HalfOpenStatus.java
@@ -43,10 +43,6 @@ public class HalfOpenStatus extends CircuitBreakerStatus {
         this.calledResult = new ArrayList<>(maxRequest * 2);
     }
 
-    public int getMaxRequest() {
-        return maxRequest;
-    }
-
     public boolean report(boolean success) {
         synchronized (lock) {
             calledResult.add(success);

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/DefaultConfigFileService.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/DefaultConfigFileService.java
@@ -18,6 +18,7 @@
 package com.tencent.polaris.configuration.client;
 
 import com.tencent.polaris.api.exception.PolarisException;
+import com.tencent.polaris.annonation.JustForTest;
 import com.tencent.polaris.client.api.BaseEngine;
 import com.tencent.polaris.client.api.SDKContext;
 import com.tencent.polaris.configuration.api.core.ConfigFile;

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/flow/DefaultConfigFileFlow.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/flow/DefaultConfigFileFlow.java
@@ -24,7 +24,7 @@ import com.tencent.polaris.configuration.api.core.ConfigFileFormat;
 import com.tencent.polaris.configuration.api.core.ConfigFileMetadata;
 import com.tencent.polaris.configuration.api.core.ConfigKVFile;
 import com.tencent.polaris.configuration.api.flow.ConfigFileFlow;
-import com.tencent.polaris.configuration.client.JustForTest;
+import com.tencent.polaris.annonation.JustForTest;
 import com.tencent.polaris.configuration.client.internal.ConfigFileManager;
 
 public class DefaultConfigFileFlow implements ConfigFileFlow {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileGroupManager.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileGroupManager.java
@@ -21,6 +21,7 @@ import com.tencent.polaris.api.exception.ServerCodes;
 import com.tencent.polaris.api.plugin.common.PluginTypes;
 import com.tencent.polaris.api.plugin.configuration.ConfigFile;
 import com.tencent.polaris.api.plugin.configuration.ConfigFileGroupConnector;
+import com.tencent.polaris.api.utils.StringUtils;
 import com.tencent.polaris.client.api.SDKContext;
 import com.tencent.polaris.configuration.api.core.ConfigFileGroup;
 import com.tencent.polaris.configuration.api.core.ConfigFileGroupMetadata;
@@ -32,17 +33,26 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class ConfigFileGroupManager {
-    private final Map<ConfigFileGroupMetadata, RevisableConfigFileGroup> configFileGroupCache = new ConcurrentHashMap<>();
+    private final Map<ConfigFileGroupMetadata, RevisableConfigFileGroup> configFileGroupCache =
+            new ConcurrentHashMap<>();
     private RetryableConfigFileGroupConnector rpcConnector;
     private RevisableConfigFileGroupPullService configFileGroupPullService;
+
+    private final boolean enabled;
 
     public ConfigFileGroupManager(SDKContext sdkContext) {
         String configFileConnectorType = sdkContext.getConfig().getConfigFile().getServerConnector()
                 .getConnectorType();
-        ConfigFileGroupConnector connector = (ConfigFileGroupConnector) sdkContext.getExtensions().getPlugins()
-                .getPlugin(PluginTypes.CONFIG_FILE_GROUP_CONNECTOR.getBaseType(), configFileConnectorType);
-        this.rpcConnector = new RetryableConfigFileGroupConnector(connector, getCacheMissedRetryStrategy());
-        this.configFileGroupPullService = new DefaultRevisableConfigFileGroupPullService(sdkContext, configFileGroupCache, connector);
+        if (StringUtils.equals(configFileConnectorType, "polaris")) {
+            enabled = true;
+            ConfigFileGroupConnector connector = (ConfigFileGroupConnector) sdkContext.getExtensions().getPlugins()
+                    .getPlugin(PluginTypes.CONFIG_FILE_GROUP_CONNECTOR.getBaseType(), configFileConnectorType);
+            this.rpcConnector = new RetryableConfigFileGroupConnector(connector, getCacheMissedRetryStrategy());
+            this.configFileGroupPullService = new DefaultRevisableConfigFileGroupPullService(sdkContext,
+                    configFileGroupCache, connector);
+        } else {
+            enabled = false;
+        }
     }
 
     public RetryableConfigFileGroupConnector.RetryableValidator getCacheMissedRetryStrategy() {
@@ -58,6 +68,9 @@ public class ConfigFileGroupManager {
     }
 
     public ConfigFileGroup getConfigFileGroup(ConfigFileGroupMetadata metadata) {
+        if (!enabled) {
+            throw new RuntimeException("Config file group manager is disabled.");
+        }
         RevisableConfigFileGroup configFileGroup = configFileGroupCache.get(metadata);
         if (configFileGroup == null) {
             synchronized (this) {
@@ -73,7 +86,8 @@ public class ConfigFileGroupManager {
         return configFileGroup;
     }
 
-    private RevisableConfigFileGroup getConfigFileGroupFromRemote(ConfigFileGroupMetadata metadata, String currentRevision) {
+    private RevisableConfigFileGroup getConfigFileGroupFromRemote(ConfigFileGroupMetadata metadata,
+                                                                  String currentRevision) {
         com.tencent.polaris.api.plugin.configuration.ConfigFileGroupMetadata metadataRPCObj = new
                 com.tencent.polaris.api.plugin.configuration.ConfigFileGroupMetadata();
         metadataRPCObj.setFileGroupName(metadata.getFileGroupName());
@@ -94,12 +108,14 @@ public class ConfigFileGroupManager {
 
                 List<ConfigFileMetadata> configFileMetadataList = new ArrayList<>();
                 for (ConfigFile configFile : configFileList) {
-                    ConfigFileMetadata configFileMetadata = new DefaultConfigFileMetadata(configFile.getNamespace(), configFile.getFileGroup(), configFile.getFileName());
+                    ConfigFileMetadata configFileMetadata = new DefaultConfigFileMetadata(configFile.getNamespace(),
+                            configFile.getFileGroup(), configFile.getFileName());
                     configFileMetadataList.add(configFileMetadata);
                 }
                 ConfigFileGroup configFileGroup = new DefaultConfigFileGroup(configFileGroupObj.getNamespace(),
                         configFileGroupObj.getFileGroupName(), configFileMetadataList);
-                RevisableConfigFileGroup revisableConfigFileGroup = new RevisableConfigFileGroup(configFileGroup, newRevision);
+                RevisableConfigFileGroup revisableConfigFileGroup = new RevisableConfigFileGroup(configFileGroup,
+                        newRevision);
                 cache(metadata, revisableConfigFileGroup);
                 return revisableConfigFileGroup;
             }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileManager.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileManager.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+import com.tencent.polaris.api.control.Destroyable;
 import com.tencent.polaris.api.plugin.filter.ConfigFileFilterChain;
 import com.tencent.polaris.api.plugin.common.PluginTypes;
 import com.tencent.polaris.api.plugin.configuration.ConfigFileConnector;
@@ -77,6 +78,8 @@ public class ConfigFileManager {
         } catch (IOException e) {
             LOGGER.warn("config file persist handler init fail:" + e.getMessage(), e);
         }
+        //deal with the situation when the thread can't exit
+        registerDestroyHook(context);
     }
 
     public ConfigFile getConfigFile(ConfigFileMetadata configFileMetadata) {
@@ -161,4 +164,13 @@ public class ConfigFileManager {
         }
     }
 
+    private void registerDestroyHook(SDKContext context) {
+        context.registerDestroyHook(new Destroyable() {
+            @Override
+            protected void doDestroy() {
+                longPullService.doLongPullingDestroy();
+                persistentHandler.doDestroy();
+            }
+        });
+    }
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileManager.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileManager.java
@@ -27,7 +27,7 @@ import com.tencent.polaris.configuration.api.core.ConfigFile;
 import com.tencent.polaris.configuration.api.core.ConfigFileFormat;
 import com.tencent.polaris.configuration.api.core.ConfigFileMetadata;
 import com.tencent.polaris.configuration.api.core.ConfigKVFile;
-import com.tencent.polaris.configuration.client.JustForTest;
+import com.tencent.polaris.annonation.JustForTest;
 
 import java.io.IOException;
 import java.util.Map;

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -42,6 +43,7 @@ import com.tencent.polaris.client.api.SDKContext;
 import com.tencent.polaris.client.util.NamedThreadFactory;
 import com.tencent.polaris.client.util.Utils;
 import com.tencent.polaris.api.plugin.configuration.ConfigFile;
+import com.tencent.polaris.api.utils.ThreadPoolUtils;
 import com.tencent.polaris.factory.util.FileUtils;
 import com.tencent.polaris.logging.LoggerFactory;
 import org.slf4j.Logger;
@@ -308,4 +310,7 @@ public class ConfigFilePersistentHandler {
 		}
 	}
 
+	protected void doDestroy() {
+		ThreadPoolUtils.waitAndStopThreadPools(new ExecutorService[]{persistExecutor});
+    }
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
@@ -67,7 +67,6 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
                                 ConfigFileMetadata configFileMetadata,
                                 ConfigFilePersistentHandler handler) {
         super(sdkContext, configFileMetadata);
-
         this.remoteConfigFile = new AtomicReference<>();
         this.notifiedVersion = new AtomicLong(INIT_VERSION);
         this.retryPolicy = new ExponentialRetryPolicy(1, 120);
@@ -81,7 +80,6 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
         //加入到长轮询的池子里
         addToLongPollingPool(pullService, configFileMetadata);
         startCheckVersionTask();
-        registerRepoDestroyHook(sdkContext);
     }
 
     private void addToLongPollingPool(ConfigFileLongPullService pullService, ConfigFileMetadata configFileMetadata) {
@@ -250,7 +248,7 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
         return configFile;
     }
 
-    private void registerRepoDestroyHook(SDKContext context) {
+    public static void registerRepoDestroyHook(SDKContext context) {
         context.registerDestroyHook(new Destroyable() {
             @Override
             protected void doDestroy() {
@@ -259,7 +257,7 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
         });
     }
 
-    protected void destroyPullExecutor() {
+    static void destroyPullExecutor() {
         ThreadPoolUtils.waitAndStopThreadPools(new ExecutorService[]{pullExecutorService});
     }
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
@@ -45,7 +45,7 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
 
     private static final int PULL_CONFIG_RETRY_TIMES = 3;
 
-    private static final ScheduledExecutorService pullExecutorService;
+    private static ScheduledExecutorService pullExecutorService;
 
     private final AtomicReference<ConfigFile> remoteConfigFile;
     //服务端通知的版本号，此版本号有可能落后于服务端
@@ -57,7 +57,7 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
     private final boolean fallbackToLocalCache;
 
     static {
-        pullExecutorService = Executors.newScheduledThreadPool(1, new NamedThreadFactory("Configuration-Pull"));
+        createPullExecutorService();
     }
 
     public RemoteConfigFileRepo(SDKContext sdkContext,
@@ -67,6 +67,8 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
                                 ConfigFileMetadata configFileMetadata,
                                 ConfigFilePersistentHandler handler) {
         super(sdkContext, configFileMetadata);
+        //保证线程池正常初始化
+        createPullExecutorService();
         this.remoteConfigFile = new AtomicReference<>();
         this.notifiedVersion = new AtomicLong(INIT_VERSION);
         this.retryPolicy = new ExponentialRetryPolicy(1, 120);
@@ -75,11 +77,19 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
         //获取远程调用插件实现类
         this.configFileConnector = connector;
         this.fallbackToLocalCache = sdkContext.getConfig().getConfigFile().getServerConnector().getFallbackToLocalCache();
+        //注册 destroy hook
+        registerRepoDestroyHook(sdkContext);
         //同步从远程仓库拉取一次
         pull();
         //加入到长轮询的池子里
         addToLongPollingPool(pullService, configFileMetadata);
         startCheckVersionTask();
+    }
+
+    private static void createPullExecutorService() {
+        if (pullExecutorService == null || pullExecutorService.isShutdown() || pullExecutorService.isTerminated()) {
+            pullExecutorService = Executors.newScheduledThreadPool(1, new NamedThreadFactory("Configuration-Pull"));
+        }
     }
 
     private void addToLongPollingPool(ConfigFileLongPullService pullService, ConfigFileMetadata configFileMetadata) {

--- a/polaris-configuration/pom.xml
+++ b/polaris-configuration/pom.xml
@@ -27,11 +27,5 @@
             <artifactId>gson</artifactId>
             <version>2.9.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>4.3.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/core/ProviderAPI.java
+++ b/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/core/ProviderAPI.java
@@ -18,10 +18,13 @@
 package com.tencent.polaris.api.core;
 
 import com.tencent.polaris.api.exception.PolarisException;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractResponse;
 import com.tencent.polaris.api.rpc.InstanceDeregisterRequest;
 import com.tencent.polaris.api.rpc.InstanceHeartbeatRequest;
 import com.tencent.polaris.api.rpc.InstanceRegisterRequest;
 import com.tencent.polaris.api.rpc.InstanceRegisterResponse;
+
 import java.io.Closeable;
 
 /**
@@ -48,7 +51,7 @@ public interface ProviderAPI extends AutoCloseable, Closeable {
      * @return 服务实例ID
      * @throws PolarisException 错误码及异常信息
      * @deprecated Recommend to use #{@link ProviderAPI#registerInstance(InstanceRegisterRequest)} method instead when
-     *         using polaris-server v1.10.0
+     * using polaris-server v1.10.0
      */
     @Deprecated
     InstanceRegisterResponse register(InstanceRegisterRequest req) throws PolarisException;
@@ -67,10 +70,18 @@ public interface ProviderAPI extends AutoCloseable, Closeable {
      * @param req 服务实例ID
      * @throws PolarisException 错误码及异常信息
      * @deprecated Recommend to use #{@link ProviderAPI#registerInstance(InstanceRegisterRequest)} method instead when
-     *         using polaris-server v1.10.0
+     * using polaris-server v1.10.0
      */
     @Deprecated
     void heartbeat(InstanceHeartbeatRequest req) throws PolarisException;
+
+    /**
+     * Report service contract.
+     *
+     * @throws PolarisException
+     * @since 1.15.0
+     */
+    ReportServiceContractResponse reportServiceContract(ReportServiceContractRequest req) throws PolarisException;
 
     /**
      * 清理并释放资源

--- a/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/flow/DiscoveryFlow.java
+++ b/polaris-discovery/polaris-discovery-api/src/main/java/com/tencent/polaris/api/flow/DiscoveryFlow.java
@@ -17,6 +17,8 @@
 
 package com.tencent.polaris.api.flow;
 
+import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractResponse;
 import com.tencent.polaris.api.rpc.GetAllInstancesRequest;
 import com.tencent.polaris.api.rpc.GetHealthyInstancesRequest;
 import com.tencent.polaris.api.rpc.GetServiceRuleRequest;
@@ -74,6 +76,10 @@ public interface DiscoveryFlow extends AbstractFlow {
 
     }
 
-	void destroy();
+    default ReportServiceContractResponse reportServiceContract(ReportServiceContractRequest req) {
+        return null;
+    }
+
+    void destroy();
 
 }

--- a/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/api/DefaultProviderAPI.java
+++ b/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/api/DefaultProviderAPI.java
@@ -3,6 +3,8 @@ package com.tencent.polaris.discovery.client.api;
 import com.tencent.polaris.api.core.ProviderAPI;
 import com.tencent.polaris.api.exception.PolarisException;
 import com.tencent.polaris.api.flow.DiscoveryFlow;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractResponse;
 import com.tencent.polaris.api.rpc.InstanceDeregisterRequest;
 import com.tencent.polaris.api.rpc.InstanceHeartbeatRequest;
 import com.tencent.polaris.api.rpc.InstanceRegisterRequest;
@@ -43,9 +45,9 @@ public class DefaultProviderAPI extends BaseEngine implements ProviderAPI {
     protected void doDestroy() {
         RegisterStateManager.destroy(sdkContext);
         super.doDestroy();
-		if (discoveryFlow != null) {
-			discoveryFlow.destroy();
-		}
+        if (discoveryFlow != null) {
+            discoveryFlow.destroy();
+        }
     }
 
     @Override
@@ -69,4 +71,10 @@ public class DefaultProviderAPI extends BaseEngine implements ProviderAPI {
         discoveryFlow.heartbeat(req);
     }
 
+    @Override
+    public ReportServiceContractResponse reportServiceContract(ReportServiceContractRequest req) throws PolarisException {
+        checkAvailable("ProviderAPI");
+        Validator.validateReportServiceContractRequest(req);
+        return discoveryFlow.reportServiceContract(req);
+    }
 }

--- a/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/flow/WatchFlow.java
+++ b/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/flow/WatchFlow.java
@@ -76,6 +76,7 @@ public class WatchFlow {
      * @return WatchServiceResponse
      */
     public WatchServiceResponse commonWatchService(CommonWatchServiceRequest request) throws PolarisException {
+        extensions.getLocalRegistry().watchResource(request.getSvcEventKey());
         ServiceKey serviceKey = request.getSvcEventKey().getServiceKey();
         InstancesResponse response = syncFlow.commonSyncGetAllInstances(request.getAllRequest());
         watchers.computeIfAbsent(request.getSvcEventKey().getServiceKey(),
@@ -111,9 +112,13 @@ public class WatchFlow {
 
         if (request.getRequest().isRemoveAll()) {
             watchers.remove(request.getSvcEventKey().getServiceKey());
+            extensions.getLocalRegistry().unwatchResource(request.getSvcEventKey());
         } else {
             if (CollectionUtils.isNotEmpty(listeners)) {
                 result = listeners.removeAll(request.getRequest().getListeners());
+            }
+            if (CollectionUtils.isEmpty(listeners)) {
+                extensions.getLocalRegistry().unwatchResource(request.getSvcEventKey());
             }
         }
 

--- a/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/util/Validator.java
+++ b/polaris-discovery/polaris-discovery-client/src/main/java/com/tencent/polaris/discovery/client/util/Validator.java
@@ -20,13 +20,27 @@ package com.tencent.polaris.discovery.client.util;
 
 import com.tencent.polaris.api.exception.ErrorCode;
 import com.tencent.polaris.api.exception.PolarisException;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
 import com.tencent.polaris.api.pojo.RetStatus;
 import com.tencent.polaris.api.pojo.ServiceEventKey;
 import com.tencent.polaris.api.pojo.ServiceKey;
-import com.tencent.polaris.api.rpc.*;
+import com.tencent.polaris.api.rpc.BaseEntity;
+import com.tencent.polaris.api.rpc.GetAllInstancesRequest;
+import com.tencent.polaris.api.rpc.GetHealthyInstancesRequest;
+import com.tencent.polaris.api.rpc.GetInstancesRequest;
+import com.tencent.polaris.api.rpc.GetOneInstanceRequest;
+import com.tencent.polaris.api.rpc.GetResourcesRequest;
+import com.tencent.polaris.api.rpc.GetServiceRuleRequest;
+import com.tencent.polaris.api.rpc.InstanceDeregisterRequest;
+import com.tencent.polaris.api.rpc.InstanceHeartbeatRequest;
+import com.tencent.polaris.api.rpc.InstanceRegisterRequest;
+import com.tencent.polaris.api.rpc.ServiceCallResult;
+import com.tencent.polaris.api.rpc.UnWatchServiceRequest;
+import com.tencent.polaris.api.rpc.WatchServiceRequest;
 import com.tencent.polaris.api.utils.CollectionUtils;
 import com.tencent.polaris.api.utils.StringUtils;
 import com.tencent.polaris.client.util.CommonValidator;
+
 import java.util.Set;
 
 /**
@@ -208,6 +222,16 @@ public class Validator {
         }
         validateHostPort(request.getHost(), request.getPort());
         CommonValidator.validateNamespaceService(request.getNamespace(), request.getService());
+    }
+
+    /**
+     * Validate report service contract request.
+     *
+     * @param request report service contract request
+     * @throws PolarisException exception
+     */
+    public static void validateReportServiceContractRequest(ReportServiceContractRequest request) throws PolarisException {
+        
     }
 
     private static void checkCommon(BaseEntity entity) throws PolarisException {

--- a/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/registry/LocalRegistry.java
+++ b/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/registry/LocalRegistry.java
@@ -112,4 +112,18 @@ public interface LocalRegistry extends Plugin {
      * @param listener 监听器
      */
     void registerResourceListener(ResourceEventListener listener);
+
+    /**
+     * 提示缓存某个服务被 Watch 监听了变化
+     *
+     * @param svcEventKey
+     */
+    void watchResource(ServiceEventKey svcEventKey);
+
+    /**
+     * 提示缓存某个服务取消 Watch 监听了变化
+     *
+     * @param svcEventKey
+     */
+    void unwatchResource(ServiceEventKey svcEventKey);
 }

--- a/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/InterfaceDescriptor.java
+++ b/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/InterfaceDescriptor.java
@@ -1,0 +1,66 @@
+/*
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ *  Licensed under the BSD 3-Clause License (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.api.plugin.server;
+
+/**
+ * Descriptor of interface.
+ *
+ * @author Haotian Zhang
+ */
+public class InterfaceDescriptor {
+
+    private String id;
+
+    private String method;
+
+    private String path;
+
+    private String content;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/ReportServiceContractRequest.java
+++ b/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/ReportServiceContractRequest.java
@@ -1,0 +1,100 @@
+/*
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ *  Licensed under the BSD 3-Clause License (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.api.plugin.server;
+
+import com.tencent.polaris.api.rpc.RequestBaseEntity;
+
+import java.util.List;
+
+/**
+ * Request of reporting service contract.
+ *
+ * @author Haotian Zhang
+ */
+public class ReportServiceContractRequest extends RequestBaseEntity {
+
+    private String name;
+
+    private String namespace;
+
+    private String service;
+
+    private String protocol;
+
+    private String version;
+
+    private List<InterfaceDescriptor> interfaceDescriptors;
+
+    private TargetServer targetServer;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public List<InterfaceDescriptor> getInterfaceDescriptors() {
+        return interfaceDescriptors;
+    }
+
+    public void setInterfaceDescriptors(List<InterfaceDescriptor> interfaceDescriptors) {
+        this.interfaceDescriptors = interfaceDescriptors;
+    }
+
+    public TargetServer getTargetServer() {
+        return targetServer;
+    }
+
+    public void setTargetServer(TargetServer targetServer) {
+        this.targetServer = targetServer;
+    }
+}

--- a/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/ReportServiceContractResponse.java
+++ b/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/ReportServiceContractResponse.java
@@ -1,0 +1,26 @@
+/*
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ *  Licensed under the BSD 3-Clause License (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.api.plugin.server;
+
+/**
+ * Response of reporting service contract.
+ *
+ * @author Haotian Zhang
+ */
+public class ReportServiceContractResponse {
+}

--- a/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/ServerConnector.java
+++ b/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/server/ServerConnector.java
@@ -20,6 +20,7 @@ package com.tencent.polaris.api.plugin.server;
 import com.tencent.polaris.api.exception.PolarisException;
 import com.tencent.polaris.api.plugin.Plugin;
 import com.tencent.polaris.api.pojo.ServiceEventKey;
+
 import java.util.Map;
 
 /**
@@ -49,7 +50,7 @@ public interface ServerConnector extends Plugin {
     /**
      * 同步注册服务
      *
-     * @param req 注册请求
+     * @param req          注册请求
      * @param customHeader 自定义请求头
      * @return 注册应答
      * @throws PolarisException 注册过程出现的错误
@@ -83,6 +84,14 @@ public interface ServerConnector extends Plugin {
     ReportClientResponse reportClient(ReportClientRequest req) throws PolarisException;
 
     /**
+     * Report service contract.
+     *
+     * @throws PolarisException
+     * @since 1.15.0
+     */
+    ReportServiceContractResponse reportServiceContract(ReportServiceContractRequest req) throws PolarisException;
+
+    /**
      * 更新服务端地址
      *
      * @param svcEventKey 新的资源key
@@ -99,16 +108,23 @@ public interface ServerConnector extends Plugin {
 
 
     /**
-     * Get id of server connector.
+     * Check if register enabled.
      *
-     * @return id
+     * @return boolean
      */
     boolean isRegisterEnable();
 
     /**
-     * Get id of server connector.
+     * Check if discovery enabled.
      *
-     * @return id
+     * @return boolean
      */
     boolean isDiscoveryEnable();
+
+    /**
+     * Check if service contract reporting enabled.
+     *
+     * @return boolean
+     */
+    boolean isReportServiceContractEnable();
 }

--- a/polaris-plugins/polaris-plugins-circuitbreaker/circuitbreaker-composite/src/main/java/com/tencent/polaris/plugins/circuitbreaker/composite/CircuitBreakerRuleContainer.java
+++ b/polaris-plugins/polaris-plugins-circuitbreaker/circuitbreaker-composite/src/main/java/com/tencent/polaris/plugins/circuitbreaker/composite/CircuitBreakerRuleContainer.java
@@ -100,7 +100,9 @@ public class CircuitBreakerRuleContainer {
                 } else {
                     ResourceCounters oldCounters = resourceResourceCounters.remove(resource);
                     if (null != oldCounters) {
+                        LOG.info("start to destroyed counters {} for resource {}", oldCounters.getCurrentActiveRule().getName(), resource);
                         // remove the old health check scheduler
+                        oldCounters.setDestroyed(true);
                         scheduleHealthCheck();
                     }
                 }

--- a/polaris-plugins/polaris-plugins-circuitbreaker/circuitbreaker-composite/src/main/java/com/tencent/polaris/plugins/circuitbreaker/composite/ResourceCounters.java
+++ b/polaris-plugins/polaris-plugins-circuitbreaker/circuitbreaker-composite/src/main/java/com/tencent/polaris/plugins/circuitbreaker/composite/ResourceCounters.java
@@ -368,7 +368,7 @@ public class ResourceCounters implements StatusChangeHandler {
             circuitBreakerStatusReference.set(circuitBreakerStatus);
             CB_EVENT_LOG.info("previous status {}, current status {}, resource {}, rule {}",
                     circuitBreakerStatus.getStatus(),
-                    "DESTROY", resource, circuitBreakerStatus.getCircuitBreaker());
+                    Status.DESTROY, resource, circuitBreakerStatus.getCircuitBreaker());
             for (TriggerCounter triggerCounter : counters) {
                 triggerCounter.resume();
             }

--- a/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
+++ b/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
@@ -20,6 +20,17 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.tencent.polaris</groupId>
+            <artifactId>polaris-logging</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
             <version>1.76</version>

--- a/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
+++ b/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
@@ -21,14 +21,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.68</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>4.3.1</version>
-            <scope>test</scope>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.76</version>
         </dependency>
         <dependency>
             <groupId>com.tencent.polaris</groupId>

--- a/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/src/main/java/com/tencent/polaris/plugins/configfilefilter/CryptoConfigFileFilter.java
+++ b/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/src/main/java/com/tencent/polaris/plugins/configfilefilter/CryptoConfigFileFilter.java
@@ -29,7 +29,7 @@ import com.tencent.polaris.api.plugin.configuration.ConfigFile;
 import com.tencent.polaris.api.plugin.configuration.ConfigFileResponse;
 import com.tencent.polaris.api.plugin.filter.ConfigFileFilter;
 import com.tencent.polaris.api.plugin.filter.Crypto;
-import com.tencent.polaris.configuration.client.JustForTest;
+import com.tencent.polaris.annonation.JustForTest;
 import com.tencent.polaris.factory.config.configuration.CryptoConfigImpl;
 import com.tencent.polaris.logging.LoggerFactory;
 import com.tencent.polaris.plugins.configfilefilter.service.RSAService;

--- a/polaris-plugins/polaris-plugins-configuration-connector/local-file-configuration-connector/src/main/java/com/tencent/polaris/plugins/configuration/connector/localfile/LocalFileConfigFileConnector.java
+++ b/polaris-plugins/polaris-plugins-configuration-connector/local-file-configuration-connector/src/main/java/com/tencent/polaris/plugins/configuration/connector/localfile/LocalFileConfigFileConnector.java
@@ -36,6 +36,7 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -84,6 +85,9 @@ public class LocalFileConfigFileConnector implements ConfigFileConnector {
 
 	@Override
 	public void init(InitContext ctx) throws PolarisException {
+		if (!Objects.equals(ctx.getConfig().getConfigFile().getServerConnector().getConnectorType(), LOCAL_FILE_CONNECTOR_TYPE)) {
+			return;
+		}
 		String dirPath = ctx.getConfig().getConfigFile().getServerConnector().getPersistDir();
 		if (StringUtils.isBlank(dirPath)) {
 			dirPath = DefaultValues.CONFIG_FILE_DEFAULT_CACHE_PERSIST_DIR;

--- a/polaris-plugins/polaris-plugins-connector/connector-common/src/main/java/com/tencent/polaris/plugins/connector/common/ServiceUpdateTask.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-common/src/main/java/com/tencent/polaris/plugins/connector/common/ServiceUpdateTask.java
@@ -119,6 +119,10 @@ public abstract class ServiceUpdateTask implements Runnable, Comparable<ServiceU
 
     public abstract boolean notifyServerEvent(ServerEvent serverEvent);
 
+    public Status getTaskStatus() {
+        return taskStatus.get();
+    }
+
     /**
      * 加入调度队列
      */

--- a/polaris-plugins/polaris-plugins-connector/connector-composite/src/main/java/com/tencent/polaris/plugins/connector/composite/CompositeConnector.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-composite/src/main/java/com/tencent/polaris/plugins/connector/composite/CompositeConnector.java
@@ -28,6 +28,8 @@ import com.tencent.polaris.api.plugin.server.CommonProviderRequest;
 import com.tencent.polaris.api.plugin.server.CommonProviderResponse;
 import com.tencent.polaris.api.plugin.server.ReportClientRequest;
 import com.tencent.polaris.api.plugin.server.ReportClientResponse;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractResponse;
 import com.tencent.polaris.api.plugin.server.ServerConnector;
 import com.tencent.polaris.api.plugin.server.ServiceEventHandler;
 import com.tencent.polaris.api.pojo.ServiceEventKey;
@@ -38,13 +40,14 @@ import com.tencent.polaris.logging.LoggerFactory;
 import com.tencent.polaris.plugins.connector.common.DestroyableServerConnector;
 import com.tencent.polaris.plugins.connector.common.ServiceUpdateTask;
 import com.tencent.polaris.plugins.connector.common.constant.ServiceUpdateTaskConstant.Type;
+import org.slf4j.Logger;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
 
 /**
  * An implement of {@link ServerConnector} to connect to Multiple Naming Server.It provides methods to manage resources
@@ -95,6 +98,11 @@ public class CompositeConnector extends DestroyableServerConnector {
 
     @Override
     public boolean isDiscoveryEnable() {
+        return true;
+    }
+
+    @Override
+    public boolean isReportServiceContractEnable() {
         return true;
     }
 
@@ -202,6 +210,19 @@ public class CompositeConnector extends DestroyableServerConnector {
         ReportClientResponse response = null;
         for (DestroyableServerConnector sc : serverConnectors) {
             ReportClientResponse temp = sc.reportClient(req);
+            if (DefaultPlugins.SERVER_CONNECTOR_GRPC.equals(sc.getName())) {
+                response = temp;
+            }
+        }
+        return response;
+    }
+
+    @Override
+    public ReportServiceContractResponse reportServiceContract(ReportServiceContractRequest req) throws PolarisException {
+        checkDestroyed();
+        ReportServiceContractResponse response = null;
+        for (DestroyableServerConnector sc : serverConnectors) {
+            ReportServiceContractResponse temp = sc.reportServiceContract(req);
             if (DefaultPlugins.SERVER_CONNECTOR_GRPC.equals(sc.getName())) {
                 response = temp;
             }

--- a/polaris-plugins/polaris-plugins-connector/connector-consul/src/main/java/com/tencent/polaris/plugins/connector/consul/ConsulAPIConnector.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-consul/src/main/java/com/tencent/polaris/plugins/connector/consul/ConsulAPIConnector.java
@@ -45,6 +45,8 @@ import com.tencent.polaris.api.plugin.server.CommonProviderRequest;
 import com.tencent.polaris.api.plugin.server.CommonProviderResponse;
 import com.tencent.polaris.api.plugin.server.ReportClientRequest;
 import com.tencent.polaris.api.plugin.server.ReportClientResponse;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractResponse;
 import com.tencent.polaris.api.plugin.server.ServerConnector;
 import com.tencent.polaris.api.plugin.server.ServiceEventHandler;
 import com.tencent.polaris.api.pojo.DefaultInstance;
@@ -138,6 +140,11 @@ public class ConsulAPIConnector extends DestroyableServerConnector {
     @Override
     public boolean isDiscoveryEnable() {
         return isDiscoveryEnable;
+    }
+
+    @Override
+    public boolean isReportServiceContractEnable() {
+        return false;
     }
 
     @Override
@@ -418,7 +425,7 @@ public class ConsulAPIConnector extends DestroyableServerConnector {
                 serviceList = new ArrayList<>(consulClient.getCatalogServices(QueryParams.DEFAULT).getValue()
                         .keySet());
             }
-            
+
             for (String s : serviceList) {
                 ServiceInfo serviceInfo = new ServiceInfo();
                 serviceInfo.setService(s);
@@ -434,6 +441,11 @@ public class ConsulAPIConnector extends DestroyableServerConnector {
 
     @Override
     public ReportClientResponse reportClient(ReportClientRequest req) throws PolarisException {
+        return null;
+    }
+
+    @Override
+    public ReportServiceContractResponse reportServiceContract(ReportServiceContractRequest req) throws PolarisException {
         return null;
     }
 

--- a/polaris-plugins/polaris-plugins-connector/connector-consul/src/main/java/com/tencent/polaris/plugins/connector/consul/ConsulAPIConnector.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-consul/src/main/java/com/tencent/polaris/plugins/connector/consul/ConsulAPIConnector.java
@@ -247,8 +247,8 @@ public class ConsulAPIConnector extends DestroyableServerConnector {
                 NewService service = buildRegisterInstanceRequest(req);
                 String json = getGson().toJson(service);
                 HttpResponse rawResponse;
-                if (StringUtils.isNotBlank(req.getToken())) {
-                    String token = req.getToken();
+                if (StringUtils.isNotBlank(consulContext.getAclToken())) {
+                    String token = consulContext.getAclToken();
                     UrlParameters tokenParam = token != null ? new SingleUrlParameters("token", token) : null;
                     rawResponse = consulRawClient.makePutRequest("/v1/agent/service/register", json,
                             tokenParam);
@@ -335,7 +335,7 @@ public class ConsulAPIConnector extends DestroyableServerConnector {
             ServiceKey serviceKey = new ServiceKey(req.getNamespace(), req.getService());
             try {
                 LOG.info("Unregistering service to Consul: " + consulContext.getInstanceId());
-                this.consulClient.agentServiceDeregister(consulContext.getInstanceId(), req.getToken());
+                this.consulClient.agentServiceDeregister(consulContext.getInstanceId(), consulContext.getAclToken());
                 LOG.info("Unregistered service to Consul: " + consulContext.getInstanceId());
                 ieRegistered = false;
             } catch (ConsulException e) {
@@ -351,7 +351,7 @@ public class ConsulAPIConnector extends DestroyableServerConnector {
         if (ieRegistered) {
             ServiceKey serviceKey = new ServiceKey(req.getNamespace(), req.getService());
             try {
-                this.consulClient.agentCheckPass(consulContext.getCheckId(), null, req.getToken());
+                this.consulClient.agentCheckPass(consulContext.getCheckId(), null, consulContext.getAclToken());
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Heartbeat service to Consul: " + consulContext.getCheckId());
                 }

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosConnector.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosConnector.java
@@ -17,21 +17,6 @@
 
 package com.tencent.polaris.plugins.connector.nacos;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import com.alibaba.nacos.api.NacosFactory;
 import com.alibaba.nacos.api.PropertyKeyConst;
 import com.alibaba.nacos.api.exception.NacosException;
@@ -56,6 +41,8 @@ import com.tencent.polaris.api.plugin.server.CommonProviderRequest;
 import com.tencent.polaris.api.plugin.server.CommonProviderResponse;
 import com.tencent.polaris.api.plugin.server.ReportClientRequest;
 import com.tencent.polaris.api.plugin.server.ReportClientResponse;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractRequest;
+import com.tencent.polaris.api.plugin.server.ReportServiceContractResponse;
 import com.tencent.polaris.api.plugin.server.ServerConnector;
 import com.tencent.polaris.api.plugin.server.ServiceEventHandler;
 import com.tencent.polaris.api.pojo.DefaultInstance;
@@ -73,6 +60,20 @@ import com.tencent.polaris.plugins.connector.common.ServiceUpdateTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
 
 /**
@@ -82,593 +83,598 @@ import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
  */
 public class NacosConnector extends DestroyableServerConnector {
 
-	/**
-	 * Logger Instance.
-	 */
-	private static final Logger LOG = LoggerFactory.getLogger(NacosConnector.class);
-
-	/**
-	 * Service Instance Name Format.
-	 */
-	private static final String INSTANCE_NAME = "%s$%s@@%s#%s#%d";
-
-	/**
-	 * If server connector initialized .
-	 */
-	private final AtomicBoolean initialized = new AtomicBoolean();
-
-	/**
-	 * Connector id .
-	 */
-	private String id;
-
-	/**
-	 * Marking service registration as enabled or not .
-	 */
-	private boolean isRegisterEnable = true;
-
-	/**
-	 * Marking service discovery as enabled or not .
-	 */
-	private boolean isDiscoveryEnable = true;
-
-	/**
-	 * Nacos Config Properties .
-	 */
-	private Properties nacosProperties = new Properties();
-
-	/**
-	 * Nacos namespace & NamingService mappings .
-	 */
-	private final Map<String, NamingService> namingServices = new ConcurrentHashMap<>();
-
-	/**
-	 * Nacos namespace & NacosServiceMerger mappings .
-	 */
-	private final Map<String, NacosServiceMerger> mergers = new ConcurrentHashMap<>();
-
-	private final Object lock = new Object();
-
-	private static final int NACOS_SERVICE_PAGESIZE = 10;
-
-	@Override
-	public String getName() {
-		return DefaultPlugins.SERVER_CONNECTOR_NACOS;
-	}
-
-	@Override
-	public PluginType getType() {
-		return PluginTypes.SERVER_CONNECTOR.getBaseType();
-	}
-
-	@Override
-	public void init(InitContext ctx) throws PolarisException {
-		if (initialized.compareAndSet(false, true)) {
-			List<ServerConnectorConfigImpl> serverConnectorConfigs = ctx.getConfig().getGlobal().getServerConnectors();
-			if (CollectionUtils.isNotEmpty(serverConnectorConfigs)) {
-				for (ServerConnectorConfigImpl serverConnectorConfig : serverConnectorConfigs) {
-					if (DefaultPlugins.SERVER_CONNECTOR_NACOS.equals(serverConnectorConfig.getProtocol())) {
-						initActually(ctx, serverConnectorConfig);
-					}
-				}
-			}
-		}
-	}
-
-	private void initActually(InitContext ctx, ServerConnectorConfig connectorConfig) {
-		this.id = connectorConfig.getId();
-		if (ctx.getConfig().getProvider().getRegisterConfigMap().containsKey(id)) {
-			isRegisterEnable = ctx.getConfig().getProvider().getRegisterConfigMap().get(id).isEnable();
-		}
-		if (ctx.getConfig().getConsumer().getDiscoveryConfigMap().containsKey(id)) {
-			isDiscoveryEnable = ctx.getConfig().getConsumer().getDiscoveryConfigMap().get(id).isEnable();
-		}
-
-		this.nacosProperties = this.decodeNacosConfigProperties(connectorConfig);
-	}
-
-	private Properties decodeNacosConfigProperties(ServerConnectorConfig config) {
-		Properties properties = new Properties();
-		Map<String, String> metadata = Optional.ofNullable(config.getMetadata()).orElse(new HashMap<>());
-		if (Objects.nonNull(metadata.get(PropertyKeyConst.USERNAME))) {
-			properties.put(PropertyKeyConst.USERNAME, metadata.get(PropertyKeyConst.USERNAME));
-		}
-		if (Objects.nonNull(metadata.get(PropertyKeyConst.PASSWORD))) {
-			properties.put(PropertyKeyConst.PASSWORD, metadata.get(PropertyKeyConst.PASSWORD));
-		}
-		if (Objects.nonNull(metadata.get(PropertyKeyConst.CONTEXT_PATH))) {
-			properties.put(PropertyKeyConst.CONTEXT_PATH, metadata.get(PropertyKeyConst.CONTEXT_PATH));
-		}
-		properties.put(PropertyKeyConst.SERVER_ADDR, String.join(",", config.getAddresses()));
-		return properties;
-	}
-
-	private NamingService getOrCreateNamingService(String namespace) {
-		NamingService namingService = namingServices.get(namespace);
-		if (namingService != null) {
-			return namingService;
-		}
-
-		synchronized (lock) {
-			Properties properties = new Properties(nacosProperties);
-			if (!Objects.equals(namespace, "default")) {
-				properties.setProperty(PropertyKeyConst.NAMESPACE, namespace);
-			}
-
-			try {
-				namingService = NacosFactory.createNamingService(properties);
-			}
-			catch (NacosException e) {
-				LOG.error("[Connector][Nacos] fail to create naming service to {}, namespace {}",
-						properties.get(PropertyKeyConst.SERVER_ADDR), namespace, e);
-				return null;
-			}
-			try {
-				Thread.sleep(1000);
-			}
-			catch (InterruptedException e) {
-				e.printStackTrace();
-			}
-
-			namingServices.put(namespace, namingService);
-			mergers.put(namespace, new NacosServiceMerger(namingService));
-			return namingService;
-		}
-	}
-
-	@Override
-	public void postContextInit(Extensions ctx) throws PolarisException {
-		// do nothing
-	}
-
-	@Override
-	public void registerServiceHandler(ServiceEventHandler handler) throws PolarisException {
-		// do nothing
-	}
-
-	@Override
-	public void deRegisterServiceHandler(ServiceEventKey eventKey) throws PolarisException {
-		// do nothing
-	}
-
-	@Override
-	public CommonProviderResponse registerInstance(CommonProviderRequest req,
-			Map<String, String> customHeader) throws PolarisException {
-		CommonProviderResponse response = new CommonProviderResponse();
-
-		if (isRegisterEnable()) {
-			NamingService namingService = getOrCreateNamingService(req.getNamespace());
-
-			if (namingService == null) {
-				LOG.error("[Nacos] fail to lookup namingService for service {}", req.getService());
-				return null;
-			}
-
-			try {
-				Instance instance = buildRegisterNacosInstance(req, analyzeNacosGroup(req.getService()));
-				namingService.registerInstance(analyzeNacosService(req.getService()), analyzeNacosGroup(req.getService()), instance);
-				response.setInstanceID(instance.getInstanceId());
-			}
-			catch (NacosException e) {
-				throw new RetriableException(ErrorCode.NETWORK_ERROR,
-						String.format("[Connector][Nacos] fail to register host %s:%d service %s", req.getHost(), req.getPort(),
-								req.getService()), e);
-			}
-		}
-		return response;
-	}
-
-	@Override
-	public void deregisterInstance(CommonProviderRequest req) throws PolarisException {
-
-		try {
-			NamingService service = getOrCreateNamingService(req.getNamespace());
-
-			if (service == null) {
-				LOG.error("[Nacos] fail to lookup namingService for service {}", req.getService());
-				return;
-			}
-
-			Instance instance = buildDeregisterNacosInstance(req, analyzeNacosGroup(req.getService()));
-
-			// register with nacos naming service
-			service.deregisterInstance(analyzeNacosService(req.getService()), analyzeNacosGroup(req.getService()), instance);
-		}
-		catch (NacosException e) {
-			throw new RetriableException(ErrorCode.NETWORK_ERROR,
-					String.format("[Connector][Nacos] fail to deregister host %s:%d service %s", req.getHost(), req.getPort(),
-							req.getService()), e);
-		}
-	}
-
-	@Override
-	public void heartbeat(CommonProviderRequest req) throws PolarisException {
-		// do nothing
-	}
-
-	@Override
-	public ReportClientResponse reportClient(ReportClientRequest req) throws PolarisException {
-		return null;
-	}
-
-	@Override
-	public void updateServers(ServiceEventKey svcEventKey) {
-		// do nothing
-	}
-
-	@Override
-	public ServiceInstancesResponse syncGetServiceInstances(ServiceUpdateTask serviceUpdateTask) {
-		List<DefaultInstance> instanceList = new ArrayList<>();
-		try {
-
-			String namespace = serviceUpdateTask.getServiceEventKey().getNamespace();
-			NamingService namingService = getOrCreateNamingService(namespace);
-			NacosServiceMerger merger = mergers.get(namespace);
-
-			if (namingService == null || merger == null) {
-				LOG.error("[Connector][Nacos] fail to lookup namingService for service {}", namespace);
-				return null;
-			}
-
-			NacosServiceMerger.NacosService serviceValue = merger.createIfAbsent(serviceUpdateTask.getServiceEventKey()
-					.getServiceKey());
-
-			for (Instance service : serviceValue.getInstances()) {
-				DefaultInstance instance = new DefaultInstance();
-				instance.setId(service.getInstanceId());
-				instance.setService(service.getServiceName());
-				instance.setHost(service.getIp());
-				instance.setPort(service.getPort());
-				instance.setHealthy(service.isHealthy());
-				instance.setMetadata(Optional.ofNullable(service.getMetadata()).orElse(new HashMap<>()));
-				instance.setIsolated(!service.isEnabled());
-				instance.setWeight((int) (100 * service.getWeight()));
-
-				String protocol = instance.getMetadata().getOrDefault("protocol", "");
-				String version = instance.getMetadata().getOrDefault("version", "");
-				if (StringUtils.isNotEmpty(protocol)) {
-					instance.setProtocol(protocol);
-				}
-				if (StringUtils.isNotEmpty(version)) {
-					instance.setVersion(version);
-				}
-
-				String region = instance.getMetadata().getOrDefault("region", "");
-				String zone = instance.getMetadata().getOrDefault("zone", "");
-				String campus = instance.getMetadata().getOrDefault("campus", "");
-
-				if (StringUtils.isNotEmpty(region)) {
-					instance.setRegion(region);
-				}
-				if (StringUtils.isNotEmpty(zone)) {
-					instance.setRegion(zone);
-				}
-				if (StringUtils.isNotEmpty(campus)) {
-					instance.setRegion(campus);
-				}
-
-				instanceList.add(instance);
-			}
-			return new ServiceInstancesResponse(serviceValue.getRevision(), instanceList);
-		}
-		catch (Exception e) {
-			throw ServerErrorResponseException.build(ErrorCode.SERVER_USER_ERROR.ordinal(),
-					String.format("[Connector][Nacos] Get service instances of %s sync failed.",
-							serviceUpdateTask.getServiceEventKey().getServiceKey()));
-		}
-	}
-
-	@Override
-	public Services syncGetServices(ServiceUpdateTask serviceUpdateTask) {
-		Services services = new ServicesByProto(new ArrayList<>());
-		try {
-
-			String namespace = serviceUpdateTask.getServiceEventKey().getNamespace();
-			NamingService namingService = getOrCreateNamingService(namespace);
-
-			if (namingService == null) {
-				LOG.error("[Connector][Nacos] fail to lookup namingService for service {}", namespace);
-				return null;
-			}
-
-			int pageIndex = 1;
-			ListView<String> listView = namingService.getServicesOfServer(pageIndex, NACOS_SERVICE_PAGESIZE, DEFAULT_GROUP);
-			final Set<String> serviceNames = new LinkedHashSet<>(listView.getData());
-			int count = listView.getCount();
-			int pageNumbers = count / NACOS_SERVICE_PAGESIZE;
-			int remainder = count % NACOS_SERVICE_PAGESIZE;
-			if (remainder > 0) {
-				pageNumbers += 1;
-			}
-			// If more than 1 page
-			while (pageIndex < pageNumbers) {
-				listView = namingService.getServicesOfServer(++pageIndex, NACOS_SERVICE_PAGESIZE, DEFAULT_GROUP);
-				serviceNames.addAll(listView.getData());
-			}
-
-			serviceNames.forEach(name -> {
-				ServiceInfo serviceInfo = new ServiceInfo();
-				serviceInfo.setNamespace(namespace);
-				serviceInfo.setService(name);
-				services.getServices().add(serviceInfo);
-			});
-
-		}
-		catch (NacosException e) {
-			throw ServerErrorResponseException.build(ErrorCode.SERVER_USER_ERROR.ordinal(),
-					String.format("[Connector][Nacos] Get services of %s instances sync failed.",
-							serviceUpdateTask.getServiceEventKey().getServiceKey()));
-		}
-		return services;
-	}
-
-	@Override
-	public String getId() {
-		return this.id;
-	}
-
-	@Override
-	public boolean isRegisterEnable() {
-		return this.isRegisterEnable;
-	}
-
-	@Override
-	public boolean isDiscoveryEnable() {
-		return this.isDiscoveryEnable;
-	}
-
-	@Override
-	public boolean isInitialized() {
-		return this.initialized.get();
-	}
-
-	@Override
-	public void retryServiceUpdateTask(ServiceUpdateTask updateTask) {
-		// do nothing
-	}
-
-	@Override
-	protected void submitServiceHandler(ServiceUpdateTask updateTask, long delayMs) {
-		// do nothing
-	}
-
-	@Override
-	public void addLongRunningTask(ServiceUpdateTask serviceUpdateTask) {
-		// do nothing
-	}
-
-	@Override
-	protected void doDestroy() {
-		if (initialized.compareAndSet(true, false)) {
-			// unsubscribe service listener
-			if (CollectionUtils.isNotEmpty(mergers)) {
-				mergers.forEach((s, serviceMerger) -> {
-					try {
-						serviceMerger.shutdown();
-					}
-					catch (Exception ignore) {
-					}
-				});
-			}
-
-			// shutdown naming service
-			if (CollectionUtils.isNotEmpty(namingServices)) {
-				namingServices.forEach((s, namingService) -> {
-					try {
-						namingService.shutDown();
-					}
-					catch (NacosException ignore) {
-					}
-				});
-			}
-		}
-	}
-
-	private Instance buildRegisterNacosInstance(CommonProviderRequest req, String group) {
-		String instanceId = String.format(INSTANCE_NAME, req.getNamespace(), group,
-				analyzeNacosService(req.getService()), req.getHost(), req.getPort());
-		Instance instance = new Instance();
-		instance.setInstanceId(instanceId);
-		instance.setEnabled(true);
-		instance.setEphemeral(true);
-		instance.setPort(req.getPort());
-		instance.setIp(req.getHost());
-		instance.setHealthy(true);
-		if (Objects.nonNull(req.getWeight())) {
-			instance.setWeight(req.getWeight());
-		}
-		instance.setServiceName(analyzeNacosService(req.getService()));
-
-		if (CollectionUtils.isNotEmpty(req.getMetadata())) {
-			if (req.getMetadata().containsKey("nacos.cluster")) {
-				instance.setClusterName(req.getMetadata().get("nacos.cluster"));
-			}
-		}
-
-		Map<String, String> metadata = new HashMap<>(Optional.ofNullable(req.getMetadata())
-				.orElse(Collections.emptyMap()));
-
-		// 填充默认 protocol 以及 version 属性信息
-		if (StringUtils.isNotEmpty(req.getProtocol())) {
-			metadata.put("protocol", req.getProtocol());
-		}
-		if (StringUtils.isNotEmpty(req.getVersion())) {
-			metadata.put("version", req.getVersion());
-		}
-
-		// 填充地域信息
-		if (StringUtils.isNotEmpty(req.getRegion())) {
-			metadata.put("region", req.getRegion());
-		}
-		if (StringUtils.isNotEmpty(req.getZone())) {
-			metadata.put("zone", req.getZone());
-		}
-		if (StringUtils.isNotEmpty(req.getCampus())) {
-			metadata.put("campus", req.getCampus());
-		}
-
-		instance.setMetadata(metadata);
-		return instance;
-	}
-
-	private Instance buildDeregisterNacosInstance(CommonProviderRequest req, String group) {
-		String instanceId = String.format(INSTANCE_NAME, req.getNamespace(), group,
-				analyzeNacosService(req.getService()), req.getHost(), req.getPort());
-		Instance instance = new Instance();
-		instance.setInstanceId(instanceId);
-		instance.setEnabled(true);
-		instance.setEphemeral(true);
-		instance.setPort(req.getPort());
-		instance.setIp(req.getHost());
-		instance.setHealthy(true);
-
-		if (CollectionUtils.isNotEmpty(req.getMetadata())) {
-			if (req.getMetadata().containsKey("nacos.cluster")) {
-				instance.setClusterName(req.getMetadata().get("nacos.cluster"));
-			}
-		}
-
-		return instance;
-	}
-
-	protected static String analyzeNacosService(String service) {
-		String[] detail = service.split("__");
-		if (detail.length == 1) {
-			return service;
-		}
-
-		return service.replaceFirst(detail[0] + "__", "");
-	}
-
-	protected static String analyzeNacosGroup(String service) {
-		String[] detail = service.split("__");
-		if (detail.length == 1 || Objects.equals(detail[0], "")) {
-			return DEFAULT_GROUP;
-		}
-		return detail[0];
-	}
-
-	private static class NacosServiceMerger {
-
-		private final NamingService namingService;
-
-		private NacosServiceMerger(NamingService service) {
-			this.namingService = service;
-		}
-
-		private final Map<ServiceKey, NacosService> services = new ConcurrentHashMap<>(8);
-
-		public void shutdown() {
-			try {
-				services.values().forEach(entry -> {
-					try {
-						namingService.unsubscribe(entry.serviceName, entry.group, entry);
-					}
-					catch (NacosException ignore) {
-					}
-				});
-
-				services.clear();
-			}
-			catch (Exception ignore) {
-			}
-		}
-
-		public synchronized NacosService createIfAbsent(ServiceKey key) throws Exception {
-			if (!services.containsKey(key)) {
-				NacosService service = new NacosService(namingService, analyzeNacosService(key.getService()),
-						analyzeNacosGroup(key.getService()));
-
-				service.init();
-
-				services.put(key, service);
-			}
-
-			return services.get(key);
-		}
-
-		private static class NacosService implements EventListener {
-
-			private final String serviceName;
-
-			private final String group;
-
-			private String revision;
-
-			private List<Instance> instances;
-
-			private final NamingService namingService;
-
-			NacosService(NamingService namingService, String serviceName, String group) {
-				this.namingService = namingService;
-				this.serviceName = serviceName;
-				this.group = group;
-			}
-
-			private void init() throws Exception {
-				instances = namingService.getAllInstances(serviceName, group);
-
-				// subscribe service instance change .
-				try {
-					namingService.subscribe(serviceName, group, this);
-				}
-				catch (NacosException e) {
-					LOG.warn("[Connector][Nacos] service subscribe failed, service name: {}, group: {}", serviceName, group, e);
-				}
-			}
-
-			private String buildRevision(List<Instance> instances) throws Exception {
-				StringBuilder revisionStr = new StringBuilder("NacosServiceInstances");
-				for (Instance instance : instances) {
-					revisionStr.append("|").append(instance.toString());
-				}
-				return MD5Utils.md5Hex(revisionStr.toString().getBytes(StandardCharsets.UTF_8));
-			}
-
-			public void rebuild(List<Instance> instances) throws Exception {
-				this.instances = instances;
-				this.revision = buildRevision(instances);
-			}
-
-
-			@Override
-			public boolean equals(Object o) {
-				if (this == o) {
-					return true;
-				}
-				if (o == null || getClass() != o.getClass()) {
-					return false;
-				}
-				NacosService that = (NacosService) o;
-				return Objects.equals(serviceName, that.serviceName) && Objects.equals(group, that.group);
-			}
-
-			@Override
-			public int hashCode() {
-				return Objects.hash(serviceName, group);
-			}
-
-			@Override
-			public void onEvent(Event event) {
-				if (event instanceof NamingEvent) {
-					NamingEvent namingEvent = (NamingEvent) event;
-					// rebuild instance cache
-					try {
-						rebuild(namingEvent.getInstances());
-					}
-					catch (Exception e) {
-						LOG.warn("[Connector][Nacos] service revision build failed, service name: {}, group: {}", serviceName, group, e);
-					}
-				}
-			}
-
-			List<Instance> getInstances() {
-				return instances;
-			}
-
-			String getRevision() {
-				return revision;
-			}
-		}
-	}
+    /**
+     * Logger Instance.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(NacosConnector.class);
+
+    /**
+     * Service Instance Name Format.
+     */
+    private static final String INSTANCE_NAME = "%s$%s@@%s#%s#%d";
+
+    /**
+     * If server connector initialized .
+     */
+    private final AtomicBoolean initialized = new AtomicBoolean();
+
+    /**
+     * Connector id .
+     */
+    private String id;
+
+    /**
+     * Marking service registration as enabled or not .
+     */
+    private boolean isRegisterEnable = true;
+
+    /**
+     * Marking service discovery as enabled or not .
+     */
+    private boolean isDiscoveryEnable = true;
+
+    /**
+     * Nacos Config Properties .
+     */
+    private Properties nacosProperties = new Properties();
+
+    /**
+     * Nacos namespace & NamingService mappings .
+     */
+    private final Map<String, NamingService> namingServices = new ConcurrentHashMap<>();
+
+    /**
+     * Nacos namespace & NacosServiceMerger mappings .
+     */
+    private final Map<String, NacosServiceMerger> mergers = new ConcurrentHashMap<>();
+
+    private final Object lock = new Object();
+
+    private static final int NACOS_SERVICE_PAGESIZE = 10;
+
+    @Override
+    public String getName() {
+        return DefaultPlugins.SERVER_CONNECTOR_NACOS;
+    }
+
+    @Override
+    public PluginType getType() {
+        return PluginTypes.SERVER_CONNECTOR.getBaseType();
+    }
+
+    @Override
+    public void init(InitContext ctx) throws PolarisException {
+        if (initialized.compareAndSet(false, true)) {
+            List<ServerConnectorConfigImpl> serverConnectorConfigs = ctx.getConfig().getGlobal().getServerConnectors();
+            if (CollectionUtils.isNotEmpty(serverConnectorConfigs)) {
+                for (ServerConnectorConfigImpl serverConnectorConfig : serverConnectorConfigs) {
+                    if (DefaultPlugins.SERVER_CONNECTOR_NACOS.equals(serverConnectorConfig.getProtocol())) {
+                        initActually(ctx, serverConnectorConfig);
+                    }
+                }
+            }
+        }
+    }
+
+    private void initActually(InitContext ctx, ServerConnectorConfig connectorConfig) {
+        this.id = connectorConfig.getId();
+        if (ctx.getConfig().getProvider().getRegisterConfigMap().containsKey(id)) {
+            isRegisterEnable = ctx.getConfig().getProvider().getRegisterConfigMap().get(id).isEnable();
+        }
+        if (ctx.getConfig().getConsumer().getDiscoveryConfigMap().containsKey(id)) {
+            isDiscoveryEnable = ctx.getConfig().getConsumer().getDiscoveryConfigMap().get(id).isEnable();
+        }
+
+        this.nacosProperties = this.decodeNacosConfigProperties(connectorConfig);
+    }
+
+    private Properties decodeNacosConfigProperties(ServerConnectorConfig config) {
+        Properties properties = new Properties();
+        Map<String, String> metadata = Optional.ofNullable(config.getMetadata()).orElse(new HashMap<>());
+        if (Objects.nonNull(metadata.get(PropertyKeyConst.USERNAME))) {
+            properties.put(PropertyKeyConst.USERNAME, metadata.get(PropertyKeyConst.USERNAME));
+        }
+        if (Objects.nonNull(metadata.get(PropertyKeyConst.PASSWORD))) {
+            properties.put(PropertyKeyConst.PASSWORD, metadata.get(PropertyKeyConst.PASSWORD));
+        }
+        if (Objects.nonNull(metadata.get(PropertyKeyConst.CONTEXT_PATH))) {
+            properties.put(PropertyKeyConst.CONTEXT_PATH, metadata.get(PropertyKeyConst.CONTEXT_PATH));
+        }
+        properties.put(PropertyKeyConst.SERVER_ADDR, String.join(",", config.getAddresses()));
+        return properties;
+    }
+
+    private NamingService getOrCreateNamingService(String namespace) {
+        NamingService namingService = namingServices.get(namespace);
+        if (namingService != null) {
+            return namingService;
+        }
+
+        synchronized (lock) {
+            Properties properties = new Properties(nacosProperties);
+            if (!Objects.equals(namespace, "default")) {
+                properties.setProperty(PropertyKeyConst.NAMESPACE, namespace);
+            }
+
+            try {
+                namingService = NacosFactory.createNamingService(properties);
+            } catch (NacosException e) {
+                LOG.error("[Connector][Nacos] fail to create naming service to {}, namespace {}",
+                        properties.get(PropertyKeyConst.SERVER_ADDR), namespace, e);
+                return null;
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            namingServices.put(namespace, namingService);
+            mergers.put(namespace, new NacosServiceMerger(namingService));
+            return namingService;
+        }
+    }
+
+    @Override
+    public void postContextInit(Extensions ctx) throws PolarisException {
+        // do nothing
+    }
+
+    @Override
+    public void registerServiceHandler(ServiceEventHandler handler) throws PolarisException {
+        // do nothing
+    }
+
+    @Override
+    public void deRegisterServiceHandler(ServiceEventKey eventKey) throws PolarisException {
+        // do nothing
+    }
+
+    @Override
+    public CommonProviderResponse registerInstance(CommonProviderRequest req,
+                                                   Map<String, String> customHeader) throws PolarisException {
+        CommonProviderResponse response = new CommonProviderResponse();
+
+        if (isRegisterEnable()) {
+            NamingService namingService = getOrCreateNamingService(req.getNamespace());
+
+            if (namingService == null) {
+                LOG.error("[Nacos] fail to lookup namingService for service {}", req.getService());
+                return null;
+            }
+
+            try {
+                Instance instance = buildRegisterNacosInstance(req, analyzeNacosGroup(req.getService()));
+                namingService.registerInstance(analyzeNacosService(req.getService()),
+                        analyzeNacosGroup(req.getService()), instance);
+                response.setInstanceID(instance.getInstanceId());
+            } catch (NacosException e) {
+                throw new RetriableException(ErrorCode.NETWORK_ERROR,
+                        String.format("[Connector][Nacos] fail to register host %s:%d service %s", req.getHost(),
+                                req.getPort(),
+                                req.getService()), e);
+            }
+        }
+        return response;
+    }
+
+    @Override
+    public void deregisterInstance(CommonProviderRequest req) throws PolarisException {
+
+        try {
+            NamingService service = getOrCreateNamingService(req.getNamespace());
+
+            if (service == null) {
+                LOG.error("[Nacos] fail to lookup namingService for service {}", req.getService());
+                return;
+            }
+
+            Instance instance = buildDeregisterNacosInstance(req, analyzeNacosGroup(req.getService()));
+
+            // register with nacos naming service
+            service.deregisterInstance(analyzeNacosService(req.getService()), analyzeNacosGroup(req.getService()),
+                    instance);
+        } catch (NacosException e) {
+            throw new RetriableException(ErrorCode.NETWORK_ERROR,
+                    String.format("[Connector][Nacos] fail to deregister host %s:%d service %s", req.getHost(),
+                            req.getPort(),
+                            req.getService()), e);
+        }
+    }
+
+    @Override
+    public void heartbeat(CommonProviderRequest req) throws PolarisException {
+        // do nothing
+    }
+
+    @Override
+    public ReportClientResponse reportClient(ReportClientRequest req) throws PolarisException {
+        return null;
+    }
+
+    @Override
+    public ReportServiceContractResponse reportServiceContract(ReportServiceContractRequest req) throws PolarisException {
+        return null;
+    }
+
+    @Override
+    public void updateServers(ServiceEventKey svcEventKey) {
+        // do nothing
+    }
+
+    @Override
+    public ServiceInstancesResponse syncGetServiceInstances(ServiceUpdateTask serviceUpdateTask) {
+        List<DefaultInstance> instanceList = new ArrayList<>();
+        try {
+
+            String namespace = serviceUpdateTask.getServiceEventKey().getNamespace();
+            NamingService namingService = getOrCreateNamingService(namespace);
+            NacosServiceMerger merger = mergers.get(namespace);
+
+            if (namingService == null || merger == null) {
+                LOG.error("[Connector][Nacos] fail to lookup namingService for service {}", namespace);
+                return null;
+            }
+
+            NacosServiceMerger.NacosService serviceValue = merger.createIfAbsent(serviceUpdateTask.getServiceEventKey()
+                    .getServiceKey());
+
+            for (Instance service : serviceValue.getInstances()) {
+                DefaultInstance instance = new DefaultInstance();
+                instance.setId(service.getInstanceId());
+                instance.setService(service.getServiceName());
+                instance.setHost(service.getIp());
+                instance.setPort(service.getPort());
+                instance.setHealthy(service.isHealthy());
+                instance.setMetadata(Optional.ofNullable(service.getMetadata()).orElse(new HashMap<>()));
+                instance.setIsolated(!service.isEnabled());
+                instance.setWeight((int) (100 * service.getWeight()));
+
+                String protocol = instance.getMetadata().getOrDefault("protocol", "");
+                String version = instance.getMetadata().getOrDefault("version", "");
+                if (StringUtils.isNotEmpty(protocol)) {
+                    instance.setProtocol(protocol);
+                }
+                if (StringUtils.isNotEmpty(version)) {
+                    instance.setVersion(version);
+                }
+
+                String region = instance.getMetadata().getOrDefault("region", "");
+                String zone = instance.getMetadata().getOrDefault("zone", "");
+                String campus = instance.getMetadata().getOrDefault("campus", "");
+
+                if (StringUtils.isNotEmpty(region)) {
+                    instance.setRegion(region);
+                }
+                if (StringUtils.isNotEmpty(zone)) {
+                    instance.setRegion(zone);
+                }
+                if (StringUtils.isNotEmpty(campus)) {
+                    instance.setRegion(campus);
+                }
+
+                instanceList.add(instance);
+            }
+            return new ServiceInstancesResponse(serviceValue.getRevision(), instanceList);
+        } catch (Exception e) {
+            throw ServerErrorResponseException.build(ErrorCode.SERVER_USER_ERROR.ordinal(),
+                    String.format("[Connector][Nacos] Get service instances of %s sync failed.",
+                            serviceUpdateTask.getServiceEventKey().getServiceKey()));
+        }
+    }
+
+    @Override
+    public Services syncGetServices(ServiceUpdateTask serviceUpdateTask) {
+        Services services = new ServicesByProto(new ArrayList<>());
+        try {
+
+            String namespace = serviceUpdateTask.getServiceEventKey().getNamespace();
+            NamingService namingService = getOrCreateNamingService(namespace);
+
+            if (namingService == null) {
+                LOG.error("[Connector][Nacos] fail to lookup namingService for service {}", namespace);
+                return null;
+            }
+
+            int pageIndex = 1;
+            ListView<String> listView = namingService.getServicesOfServer(pageIndex, NACOS_SERVICE_PAGESIZE,
+                    DEFAULT_GROUP);
+            final Set<String> serviceNames = new LinkedHashSet<>(listView.getData());
+            int count = listView.getCount();
+            int pageNumbers = count / NACOS_SERVICE_PAGESIZE;
+            int remainder = count % NACOS_SERVICE_PAGESIZE;
+            if (remainder > 0) {
+                pageNumbers += 1;
+            }
+            // If more than 1 page
+            while (pageIndex < pageNumbers) {
+                listView = namingService.getServicesOfServer(++pageIndex, NACOS_SERVICE_PAGESIZE, DEFAULT_GROUP);
+                serviceNames.addAll(listView.getData());
+            }
+
+            serviceNames.forEach(name -> {
+                ServiceInfo serviceInfo = new ServiceInfo();
+                serviceInfo.setNamespace(namespace);
+                serviceInfo.setService(name);
+                services.getServices().add(serviceInfo);
+            });
+
+        } catch (NacosException e) {
+            throw ServerErrorResponseException.build(ErrorCode.SERVER_USER_ERROR.ordinal(),
+                    String.format("[Connector][Nacos] Get services of %s instances sync failed.",
+                            serviceUpdateTask.getServiceEventKey().getServiceKey()));
+        }
+        return services;
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public boolean isRegisterEnable() {
+        return this.isRegisterEnable;
+    }
+
+    @Override
+    public boolean isDiscoveryEnable() {
+        return this.isDiscoveryEnable;
+    }
+
+    @Override
+    public boolean isReportServiceContractEnable() {
+        return false;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return this.initialized.get();
+    }
+
+    @Override
+    public void retryServiceUpdateTask(ServiceUpdateTask updateTask) {
+        // do nothing
+    }
+
+    @Override
+    protected void submitServiceHandler(ServiceUpdateTask updateTask, long delayMs) {
+        // do nothing
+    }
+
+    @Override
+    public void addLongRunningTask(ServiceUpdateTask serviceUpdateTask) {
+        // do nothing
+    }
+
+    @Override
+    protected void doDestroy() {
+        if (initialized.compareAndSet(true, false)) {
+            // unsubscribe service listener
+            if (CollectionUtils.isNotEmpty(mergers)) {
+                mergers.forEach((s, serviceMerger) -> {
+                    try {
+                        serviceMerger.shutdown();
+                    } catch (Exception ignore) {
+                    }
+                });
+            }
+
+            // shutdown naming service
+            if (CollectionUtils.isNotEmpty(namingServices)) {
+                namingServices.forEach((s, namingService) -> {
+                    try {
+                        namingService.shutDown();
+                    } catch (NacosException ignore) {
+                    }
+                });
+            }
+        }
+    }
+
+    private Instance buildRegisterNacosInstance(CommonProviderRequest req, String group) {
+        String instanceId = String.format(INSTANCE_NAME, req.getNamespace(), group,
+                analyzeNacosService(req.getService()), req.getHost(), req.getPort());
+        Instance instance = new Instance();
+        instance.setInstanceId(instanceId);
+        instance.setEnabled(true);
+        instance.setEphemeral(true);
+        instance.setPort(req.getPort());
+        instance.setIp(req.getHost());
+        instance.setHealthy(true);
+        if (Objects.nonNull(req.getWeight())) {
+            instance.setWeight(req.getWeight());
+        }
+        instance.setServiceName(analyzeNacosService(req.getService()));
+
+        if (CollectionUtils.isNotEmpty(req.getMetadata())) {
+            if (req.getMetadata().containsKey("nacos.cluster")) {
+                instance.setClusterName(req.getMetadata().get("nacos.cluster"));
+            }
+        }
+
+        Map<String, String> metadata = new HashMap<>(Optional.ofNullable(req.getMetadata())
+                .orElse(Collections.emptyMap()));
+
+        // 填充默认 protocol 以及 version 属性信息
+        if (StringUtils.isNotEmpty(req.getProtocol())) {
+            metadata.put("protocol", req.getProtocol());
+        }
+        if (StringUtils.isNotEmpty(req.getVersion())) {
+            metadata.put("version", req.getVersion());
+        }
+
+        // 填充地域信息
+        if (StringUtils.isNotEmpty(req.getRegion())) {
+            metadata.put("region", req.getRegion());
+        }
+        if (StringUtils.isNotEmpty(req.getZone())) {
+            metadata.put("zone", req.getZone());
+        }
+        if (StringUtils.isNotEmpty(req.getCampus())) {
+            metadata.put("campus", req.getCampus());
+        }
+
+        instance.setMetadata(metadata);
+        return instance;
+    }
+
+    private Instance buildDeregisterNacosInstance(CommonProviderRequest req, String group) {
+        String instanceId = String.format(INSTANCE_NAME, req.getNamespace(), group,
+                analyzeNacosService(req.getService()), req.getHost(), req.getPort());
+        Instance instance = new Instance();
+        instance.setInstanceId(instanceId);
+        instance.setEnabled(true);
+        instance.setEphemeral(true);
+        instance.setPort(req.getPort());
+        instance.setIp(req.getHost());
+        instance.setHealthy(true);
+
+        if (CollectionUtils.isNotEmpty(req.getMetadata())) {
+            if (req.getMetadata().containsKey("nacos.cluster")) {
+                instance.setClusterName(req.getMetadata().get("nacos.cluster"));
+            }
+        }
+
+        return instance;
+    }
+
+    protected static String analyzeNacosService(String service) {
+        String[] detail = service.split("__");
+        if (detail.length == 1) {
+            return service;
+        }
+
+        return service.replaceFirst(detail[0] + "__", "");
+    }
+
+    protected static String analyzeNacosGroup(String service) {
+        String[] detail = service.split("__");
+        if (detail.length == 1 || Objects.equals(detail[0], "")) {
+            return DEFAULT_GROUP;
+        }
+        return detail[0];
+    }
+
+    private static class NacosServiceMerger {
+
+        private final NamingService namingService;
+
+        private NacosServiceMerger(NamingService service) {
+            this.namingService = service;
+        }
+
+        private final Map<ServiceKey, NacosService> services = new ConcurrentHashMap<>(8);
+
+        public void shutdown() {
+            try {
+                services.values().forEach(entry -> {
+                    try {
+                        namingService.unsubscribe(entry.serviceName, entry.group, entry);
+                    } catch (NacosException ignore) {
+                    }
+                });
+
+                services.clear();
+            } catch (Exception ignore) {
+            }
+        }
+
+        public synchronized NacosService createIfAbsent(ServiceKey key) throws Exception {
+            if (!services.containsKey(key)) {
+                NacosService service = new NacosService(namingService, analyzeNacosService(key.getService()),
+                        analyzeNacosGroup(key.getService()));
+
+                service.init();
+
+                services.put(key, service);
+            }
+
+            return services.get(key);
+        }
+
+        private static class NacosService implements EventListener {
+
+            private final String serviceName;
+
+            private final String group;
+
+            private String revision;
+
+            private List<Instance> instances;
+
+            private final NamingService namingService;
+
+            NacosService(NamingService namingService, String serviceName, String group) {
+                this.namingService = namingService;
+                this.serviceName = serviceName;
+                this.group = group;
+            }
+
+            private void init() throws Exception {
+                instances = namingService.getAllInstances(serviceName, group);
+
+                // subscribe service instance change .
+                try {
+                    namingService.subscribe(serviceName, group, this);
+                } catch (NacosException e) {
+                    LOG.warn("[Connector][Nacos] service subscribe failed, service name: {}, group: {}", serviceName,
+                            group, e);
+                }
+            }
+
+            private String buildRevision(List<Instance> instances) throws Exception {
+                StringBuilder revisionStr = new StringBuilder("NacosServiceInstances");
+                for (Instance instance : instances) {
+                    revisionStr.append("|").append(instance.toString());
+                }
+                return MD5Utils.md5Hex(revisionStr.toString().getBytes(StandardCharsets.UTF_8));
+            }
+
+            public void rebuild(List<Instance> instances) throws Exception {
+                this.instances = instances;
+                this.revision = buildRevision(instances);
+            }
+
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+                NacosService that = (NacosService) o;
+                return Objects.equals(serviceName, that.serviceName) && Objects.equals(group, that.group);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(serviceName, group);
+            }
+
+            @Override
+            public void onEvent(Event event) {
+                if (event instanceof NamingEvent) {
+                    NamingEvent namingEvent = (NamingEvent) event;
+                    // rebuild instance cache
+                    try {
+                        rebuild(namingEvent.getInstances());
+                    } catch (Exception e) {
+                        LOG.warn("[Connector][Nacos] service revision build failed, service name: {}, group: {}",
+                                serviceName, group, e);
+                    }
+                }
+            }
+
+            List<Instance> getInstances() {
+                return instances;
+            }
+
+            String getRevision() {
+                return revision;
+            }
+        }
+    }
 }

--- a/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/main/java/com/tencent/polaris/plugins/connector/grpc/GrpcUtil.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/main/java/com/tencent/polaris/plugins/connector/grpc/GrpcUtil.java
@@ -12,6 +12,7 @@ import com.tencent.polaris.specification.api.v1.service.manage.ResponseProto.Dis
 import io.grpc.Metadata;
 import io.grpc.stub.AbstractStub;
 import io.grpc.stub.MetadataUtils;
+
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
@@ -35,6 +36,8 @@ public class GrpcUtil {
     public static final String OP_KEY_REPORT_CLIENT = "ReportClient";
 
     public static final String OP_KEY_CHECK_COMPATIBLE = "CheckCompatible";
+
+    public static final String OP_KEY_REPORT_SERVICE_CONTRACT = "ReportServiceContract";
 
     /**
      * 请求ID的key
@@ -63,6 +66,11 @@ public class GrpcUtil {
     private static final String REQ_ID_PREFIX_GETINSTANCES = "4";
 
     /**
+     * Prefix of request of reporting service contract.
+     */
+    private static final String REQ_ID_PREFIX_REPORTSERVICECONTRACT = "5";
+
+    /**
      * 实例发现ID发生器
      */
     private static final AtomicLong SEED_INSTANCE_REQ_ID = new AtomicLong();
@@ -81,6 +89,11 @@ public class GrpcUtil {
      * 心跳上报ID发生器
      */
     private static final AtomicLong SEED_HEARTBEAT_REQ_ID = new AtomicLong();
+
+    /**
+     * Request ID generator of reporting service contract.
+     */
+    private static final AtomicLong SEED_REPORT_SERVICE_CONTRACT_REQ_ID = new AtomicLong();
 
     /**
      * 获取下一个实例请求ID
@@ -118,12 +131,22 @@ public class GrpcUtil {
         return String.format("%s%d", REQ_ID_PREFIX_HEARTBEAT, SEED_HEARTBEAT_REQ_ID.incrementAndGet());
     }
 
+    /**
+     * Request ID of reporting service contract.
+     *
+     * @return string
+     */
+    public static String nextReportServiceContractReqId() {
+        return String.format("%s%d", REQ_ID_PREFIX_REPORTSERVICECONTRACT,
+                SEED_REPORT_SERVICE_CONTRACT_REQ_ID.incrementAndGet());
+    }
+
 
     /**
      * 为GRPC请求添加请求头部
      *
-     * @param <T> 桩类型
-     * @param stub 请求桩
+     * @param <T>    桩类型
+     * @param stub   请求桩
      * @param nextID 请求ID
      */
     public static <T extends AbstractStub<T>> void attachRequestHeader(T stub, String nextID) {
@@ -135,9 +158,9 @@ public class GrpcUtil {
     /**
      * 为GRPC请求添加自定义请求头部信息
      *
-     * @param stub 请求桩
+     * @param stub         请求桩
      * @param customHeader 自定义header
-     * @param <T> 桩类型
+     * @param <T>          桩类型
      */
     public static <T extends AbstractStub<T>> void attachRequestHeader(T stub, Map<String, String> customHeader) {
         if (MapUtils.isEmpty(customHeader)) {

--- a/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/test/java/com/tencent/polaris/plugins/connector/grpc/SpecStreamClientTest.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/test/java/com/tencent/polaris/plugins/connector/grpc/SpecStreamClientTest.java
@@ -1,0 +1,153 @@
+/*
+ * Tencent is pleased to support the open source community by making Polaris available.
+ *
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.plugins.connector.grpc;
+
+import com.google.protobuf.StringValue;
+import com.tencent.polaris.api.config.global.ClusterType;
+import com.tencent.polaris.api.plugin.server.EventHandler;
+import com.tencent.polaris.api.plugin.server.ServerEvent;
+import com.tencent.polaris.api.plugin.server.ServiceEventHandler;
+import com.tencent.polaris.api.pojo.RegistryCacheValue;
+import com.tencent.polaris.api.pojo.ServiceEventKey;
+import com.tencent.polaris.api.pojo.ServiceKey;
+import com.tencent.polaris.plugins.connector.common.ServiceUpdateTask;
+import com.tencent.polaris.plugins.connector.common.constant.ServiceUpdateTaskConstant;
+import com.tencent.polaris.specification.api.v1.service.manage.ResponseProto;
+import com.tencent.polaris.specification.api.v1.service.manage.ServiceProto;
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SpecStreamClientTest extends TestCase {
+
+    @Test
+    public void testNormalPendingTask() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        // 每秒处理
+        SpecStreamClient mockClient = new SpecStreamClient(1000);
+        mockClient.putPendingTask(MockServiceUpdateTask.build(new ServiceKey("mock_namespace", "mock_service"), (task, label) -> {
+            System.out.println(task.getTaskStatus() + " " + label);
+            Assert.assertEquals(ServiceUpdateTaskConstant.Status.READY, task.getTaskStatus());
+            Assert.assertEquals("normal", label);
+            latch.countDown();
+        }));
+
+        mockClient.onNext(ResponseProto.DiscoverResponse.newBuilder()
+                .setService(ServiceProto.Service.newBuilder()
+                        .setName(StringValue.newBuilder().setValue("mock_service").build())
+                        .setNamespace(StringValue.newBuilder().setValue("mock_namespace").build())
+                        .build())
+                .setType(ResponseProto.DiscoverResponse.DiscoverResponseType.INSTANCE)
+                .build());
+
+        latch.await();
+    }
+
+    @Test
+    public void testAbNormalPendingTask() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        // 每秒处理
+        SpecStreamClient mockClient = new SpecStreamClient(1000);
+        mockClient.putPendingTask(MockServiceUpdateTask.build(new ServiceKey("mock_namespace", "mock_service"), (task, label) -> {
+            System.out.println(task.getTaskStatus() + " " + label);
+            Assert.assertEquals(ServiceUpdateTaskConstant.Status.RUNNING, task.getTaskStatus());
+            Assert.assertEquals("retry", label);
+            latch.countDown();
+        }));
+
+        // 等待 10s 中
+        TimeUnit.SECONDS.sleep(10);
+        mockClient.onNext(ResponseProto.DiscoverResponse.newBuilder()
+                .setService(ServiceProto.Service.newBuilder()
+                        .setName(StringValue.newBuilder().setValue("mock_service").build())
+                        .setNamespace(StringValue.newBuilder().setValue("mock_namespace").build())
+                        .build())
+                .setType(ResponseProto.DiscoverResponse.DiscoverResponseType.INSTANCE)
+                .build());
+
+        latch.await();
+    }
+
+    private static final class MockServiceUpdateTask extends ServiceUpdateTask {
+
+        private final BiConsumer<MockServiceUpdateTask, String> consumer;
+
+        public static MockServiceUpdateTask build(ServiceKey serviceKey, BiConsumer<MockServiceUpdateTask, String> consumer) {
+            ServiceEventHandler handler = new ServiceEventHandler(new ServiceEventKey(serviceKey, ServiceEventKey.EventType.INSTANCE), new EventHandler() {
+                @Override
+                public boolean onEventUpdate(ServerEvent event) {
+                    return false;
+                }
+
+                @Override
+                public String getRevision() {
+                    return "" + System.currentTimeMillis();
+                }
+
+                @Override
+                public RegistryCacheValue getValue() {
+                    return null;
+                }
+            });
+            handler.setTargetCluster(ClusterType.BUILTIN_CLUSTER);
+            handler.setRefreshInterval(2000);
+            handler.setLastUpdateTimeMs(System.currentTimeMillis());
+            MockServiceUpdateTask task = new MockServiceUpdateTask(handler, consumer);
+            task.setStatus(ServiceUpdateTaskConstant.Status.READY, ServiceUpdateTaskConstant.Status.RUNNING);
+            return task;
+        }
+
+        public MockServiceUpdateTask(ServiceEventHandler handler, BiConsumer<MockServiceUpdateTask, String> consumer) {
+            super(handler, null);
+            this.consumer = consumer;
+        }
+
+        @Override
+        protected void execute() throws Throwable {
+
+        }
+
+        @Override
+        protected void handle(Throwable throwable) {
+
+        }
+
+        @Override
+        public void addUpdateTaskSet() {
+            consumer.accept(this, "normal");
+        }
+
+        @Override
+        public boolean notifyServerEvent(ServerEvent serverEvent) {
+            setStatus(ServiceUpdateTaskConstant.Status.RUNNING, ServiceUpdateTaskConstant.Status.READY);
+            return false;
+        }
+
+        @Override
+        public void retry() {
+            consumer.accept(this, "retry");
+        }
+    }
+}

--- a/polaris-plugins/polaris-plugins-connector/pom.xml
+++ b/polaris-plugins/polaris-plugins-connector/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>polaris-config</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>4.3.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/polaris-plugins/polaris-plugins-registry/registry-memory/src/main/java/com/tencent/polaris/plugins/registry/memory/CacheObject.java
+++ b/polaris-plugins/polaris-plugins-registry/registry-memory/src/main/java/com/tencent/polaris/plugins/registry/memory/CacheObject.java
@@ -84,6 +84,9 @@ public class CacheObject implements EventHandler {
     //是否已经触发了资源新增回调
     private final AtomicBoolean notifyResourceAdded = new AtomicBoolean(false);
 
+    //是否被 Watch
+    private final AtomicBoolean watched = new AtomicBoolean(false);
+
     public CacheObject(CacheHandler cacheHandler, ServiceEventKey svcEventKey, InMemoryRegistry registry) {
         this.svcEventKey = svcEventKey;
         this.registry = registry;
@@ -325,5 +328,17 @@ public class CacheObject implements EventHandler {
     @Override
     public RegistryCacheValue getValue() {
         return value.get();
+    }
+
+    public boolean isWatched() {
+        return watched.get();
+    }
+
+    public void openWatch() {
+        watched.set(true);
+    }
+
+    public void cancelWatch() {
+        watched.set(false);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <disruptor.version>3.4.4</disruptor.version>
         <log4j.version>1.2.17</log4j.version>
         <junit.version>4.13.1</junit.version>
+        <mockito.version>4.9.0</mockito.version>
         <assertj.version>3.16.1</assertj.version>
         <argLine>-Xmx2048m</argLine>
         <prometheus.version>0.11.0</prometheus.version>
@@ -133,6 +134,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
     <properties>
         <!-- Project revision -->
-        <revision>1.14.0</revision>
+        <revision>1.15.0-SNAPSHOT</revision>
 
         <timestamp>${maven.build.timestamp}</timestamp>
         <skip.maven.deploy>false</skip.maven.deploy>


### PR DESCRIPTION
修复熔断规则关闭后，没有清除缓存导致prometheus仍能采集到熔断，半熔断等状态数量