### PR TITLE
Fix connection leak

### DIFF
--- a/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/main/java/com/tencent/polaris/plugins/connector/grpc/GrpcConnector.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/main/java/com/tencent/polaris/plugins/connector/grpc/GrpcConnector.java
@@ -645,8 +645,7 @@ public class GrpcConnector extends DestroyableServerConnector {
             ResponseProto.Response reportServiceContractResponse =
                     stub.reportServiceContract(buildReportServiceContractRequest(req));
             GrpcUtil.checkResponse(reportServiceContractResponse);
-            ReportServiceContractResponse resp = new ReportServiceContractResponse();
-            return resp;
+            return new ReportServiceContractResponse();
         } catch (Throwable t) {
             if (t instanceof PolarisException) {
                 throw t;
@@ -723,6 +722,7 @@ public class GrpcConnector extends DestroyableServerConnector {
             LOG.info("start to destroy connector {}", getName());
             ThreadPoolUtils.waitAndStopThreadPools(
                     new ExecutorService[]{sendDiscoverExecutor, buildInExecutor, updateServiceExecutor});
+            destroyStreamClient();
             if (null != connectionManager) {
                 connectionManager.destroy();
             }
@@ -759,5 +759,13 @@ public class GrpcConnector extends DestroyableServerConnector {
         }
     }
 
-
+    private void destroyStreamClient() {
+        for (AtomicReference<SpecStreamClient> streamClientRef : streamClients.values()) {
+            SpecStreamClient streamClient = streamClientRef.get();
+            if (null == streamClient) {
+                continue;
+            }
+            streamClient.closeStream(true);
+        }
+    }
 }


### PR DESCRIPTION
The stream reference count can only be cleared by the scheduled task, but the thread pool that performs the clearing task has been shutdown. As a result, The connection occupied by stream cannot be released.