### PR TITLE
Fix bouncycastle scope

### DIFF
--- a/polaris-distribution/polaris-all/pom.xml
+++ b/polaris-distribution/polaris-all/pom.xml
@@ -42,6 +42,11 @@
             <version>${javax.annotation.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk15to18</artifactId>
+            <version>${bouncycastle.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -166,6 +171,11 @@
                                     <shadedPattern>shade.polaris.io.netty</shadedPattern>
                                 </relocation>
                             </relocations>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.bouncycastle:*</exclude>
+                                </excludes>
+                            </artifactSet>
                         </configuration>
                     </execution>
                 </executions>

--- a/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
+++ b/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
@@ -34,6 +34,7 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15to18</artifactId>
             <version>1.78.1</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.tencent.polaris</groupId>

--- a/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
+++ b/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/pom.xml
@@ -33,8 +33,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15to18</artifactId>
-            <version>1.78.1</version>
-            <scope>provided</scope>
+            <version>${bouncycastle.version}</version>
         </dependency>
         <dependency>
             <groupId>com.tencent.polaris</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
         <okhttp.version>2.7.5</okhttp.version>
         <httpclient.version>4.5.14</httpclient.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
+        <bouncycastle.version>1.78.1</bouncycastle.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Bouncycastle is a jar that needs to be signed, not suitable for shaded.
![image](https://github.com/user-attachments/assets/5f26f308-0806-4e75-831f-77d413c26ac8)
