### PR TITLE
fix: add getActiveRuleId method to fix javaagent ratelimit method not found error

### DIFF
--- a/polaris-ratelimit/polaris-ratelimit-api/src/main/java/com/tencent/polaris/ratelimit/api/rpc/QuotaResponse.java
+++ b/polaris-ratelimit/polaris-ratelimit-api/src/main/java/com/tencent/polaris/ratelimit/api/rpc/QuotaResponse.java
@@ -68,6 +68,10 @@ public class QuotaResponse {
         return activeRuleName;
     }
 
+    public String getActiveRuleId() {
+        return this.getActiveRule().getId().getValue();
+    }
+
     public Rule getActiveRule() {
         return activeRule;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 
     <properties>
         <!-- Project revision -->
-        <revision>2.0.0.1</revision>
+        <revision>2.0.0.2-SNAPSHOT</revision>
 
         <timestamp>${maven.build.timestamp}</timestamp>
         <skip.maven.deploy>false</skip.maven.deploy>


### PR DESCRIPTION
fix: add getActiveRuleId method to fix javaagent ratelimit method not found error
<img width="1780" alt="企业微信截图_6323ba3f-16b2-4f30-88b4-6a967154e664" src="https://github.com/user-attachments/assets/f6e3bbfa-5ba3-490b-845b-2ccfdff39158" />
