### PR TITLE
fix: fix tsf route and fix tsf rateLimit event report

### DIFF
--- a/polaris-plugins/polaris-plugins-connector/connector-consul/src/main/java/com/tencent/polaris/plugins/connector/consul/service/router/RoutingService.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-consul/src/main/java/com/tencent/polaris/plugins/connector/consul/service/router/RoutingService.java
@@ -215,6 +215,8 @@ public class RoutingService extends ConsulService {
                                     String serviceName = tagValue;
                                     if (routeTag.getTagOperator().equals(TagConstant.OPERATOR.NOT_EQUAL) || routeTag.getTagOperator().equals(TagConstant.OPERATOR.NOT_IN)) {
                                         serviceName = "!" + serviceName;
+                                    } else if (routeTag.getTagOperator().equals(TagConstant.OPERATOR.REGEX)) {
+                                        serviceName = "*" + serviceName;
                                     }
                                     sourceBuilder.setService(StringValue.of(serviceName));
                                     sourceBuilders.add(sourceBuilder);
@@ -229,6 +231,8 @@ public class RoutingService extends ConsulService {
                                     sourceBuilder.setNamespace(StringValue.of("*"));
                                     String serviceName = tagValue;
                                     if (split.length == 2) {
+                                        // namespace/service format
+                                        sourceBuilder.setNamespace(StringValue.of(split[0]));
                                         serviceName = split[1];
                                     }
                                     if (routeTag.getTagOperator().equals(TagConstant.OPERATOR.NOT_EQUAL) || routeTag.getTagOperator().equals(TagConstant.OPERATOR.NOT_IN)) {

--- a/polaris-plugins/polaris-plugins-observability/event-tsf/src/main/java/com/tencent/polaris/plugins/event/tsf/TsfEventDataUtils.java
+++ b/polaris-plugins/polaris-plugins-observability/event-tsf/src/main/java/com/tencent/polaris/plugins/event/tsf/TsfEventDataUtils.java
@@ -30,9 +30,9 @@ import java.util.Objects;
 public class TsfEventDataUtils {
 
     public static String convertEventName(BaseEvent flowEvent) {
-        if (Objects.equals(flowEvent.getEventType(), ServiceEventKey.EventType.CIRCUIT_BREAKING)) {
+        if (Objects.equals(flowEvent.getEventType(), EventConstants.EventType.CIRCUIT_BREAKING)) {
             return TsfEventDataConstants.CIRCUIT_BREAKER_EVENT_NAME;
-        } else if (Objects.equals(flowEvent.getEventType(), ServiceEventKey.EventType.RATE_LIMITING)) {
+        } else if (Objects.equals(flowEvent.getEventType(), EventConstants.EventType.RATE_LIMITING)) {
             return TsfEventDataConstants.RATE_LIMIT_EVENT_NAME;
         }
         return "";

--- a/polaris-plugins/polaris-plugins-observability/event-tsf/src/main/java/com/tencent/polaris/plugins/event/tsf/TsfEventReporter.java
+++ b/polaris-plugins/polaris-plugins-observability/event-tsf/src/main/java/com/tencent/polaris/plugins/event/tsf/TsfEventReporter.java
@@ -382,14 +382,20 @@ public class TsfEventReporter implements EventReporter, PluginConfigProvider {
             try (CloseableHttpClient httpClient = HttpClientBuilder.create().setDefaultRequestConfig(config).build()) {
 
                 HttpPost httpPost = new HttpPost(reportEventUri);
-                postBody = new StringEntity(gson.toJson(eventData));
+                String body = gson.toJson(eventData);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Report report Event To TSF event-center. body is : {}", body);
+                }
+                postBody = new StringEntity(body);
                 httpPost.setEntity(postBody);
                 httpPost.setHeader("Content-Type", "application/json");
 
                 HttpResponse httpResponse = httpClient.execute(httpPost);
                 String resultString = EntityUtils.toString(httpResponse.getEntity(), "utf-8");
                 EventResponse response = gson.fromJson(resultString, EventResponse.class);
-
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Report report Event To TSF event-center. Response is : {}", resultString);
+                }
                 if (StringUtils.isNotBlank(response.getErrorInfo())) {
                     throw new RuntimeException("Report report event failed. Response = [" + resultString + "].");
                 }

--- a/polaris-ratelimit/polaris-ratelimit-client/src/main/java/com/tencent/polaris/ratelimit/client/utils/RateLimiterEventUtils.java
+++ b/polaris-ratelimit/polaris-ratelimit-client/src/main/java/com/tencent/polaris/ratelimit/client/utils/RateLimiterEventUtils.java
@@ -75,11 +75,11 @@ public class RateLimiterEventUtils {
             flowEvent.getAdditionalParams().put(RULE_ID_KEY, rule.getName().getValue());
         }
 
-        flowEvent.getAdditionalParams().put(RULE_DETAIL_KEY, "{}");
-        // 老的SDK并没有实现
-        // if (rule.getMetadataMap().containsKey("original")) {
-        // flowEvent.getAdditionalParams().put(RULE_DETAIL_KEY, rule.getMetadataMap().get("original"));
-        // }
+         if (rule.getMetadataMap().containsKey("original")) {
+            flowEvent.getAdditionalParams().put(RULE_DETAIL_KEY, rule.getMetadataMap().get("original"));
+         } else {
+             flowEvent.getAdditionalParams().put(RULE_DETAIL_KEY, "{}");
+         }
 
         BaseFlow.reportFlowEvent(extensions, flowEvent);
     }


### PR DESCRIPTION
1. 修复 tsf 路由规则为上游命名空间服务名，不匹配 ns 
2. 修复 tsf 路由规则为服务名，不支持正则
3. 修复 tsf 限流事件上报失败的问题