### PR TITLE
fix: upgrade bouncycastle to 1.79 to fix CVE-2025-8916.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <okhttp.version>2.7.5</okhttp.version>
         <httpclient.version>4.5.14</httpclient.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
-        <bouncycastle.version>1.78.1</bouncycastle.version>
+        <bouncycastle.version>1.79</bouncycastle.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
fix: upgrade bouncycastle to 1.79 to fix CVE-2025-8916.