### PR TITLE
fix: reduce verbose logging in ServiceAddressRepository#getDiscoverInstance

### DIFF
--- a/polaris-common/polaris-client/src/main/java/com/tencent/polaris/client/remote/ServiceAddressRepository.java
+++ b/polaris-common/polaris-client/src/main/java/com/tencent/polaris/client/remote/ServiceAddressRepository.java
@@ -218,8 +218,10 @@ public class ServiceAddressRepository {
     private Instance getDiscoverInstance() throws PolarisException {
         Instance instance = BaseFlow.commonGetOneInstance(extensions, remoteCluster, routers, lbPolicy, protocol,
                 clientId);
-        LOG.info("success to get instance for service {}, instance is {}:{}", remoteCluster, instance.getHost(),
-                instance.getPort());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("success to get instance for service {}, instance is {}:{}", remoteCluster, instance.getHost(),
+                    instance.getPort());
+        }
         return instance;
     }
 


### PR DESCRIPTION
## Summary

- `ServiceAddressRepository#getDiscoverInstance()` 每次获取实例都以 INFO 级别打印日志，在高频调用场景下会产生大量冗余日志
- 将日志级别从 `LOG.info` 降为 `LOG.debug`，并增加 `isDebugEnabled()` 保护，避免不必要的字符串拼接开销

## Test plan

- [x] 代码变更仅涉及日志级别调整，无功能逻辑变化
- [ ] CI 多版本（Java 8/11/17/21/25）编译通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)