### PR TITLE
feat: add Dubbo-adaptive service name mapping for Nacos connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ dependency-reduced-pom.xml
 *.class
 .svn
 logs/
+docs/
 lib/
 backup/
 .arthas/

--- a/polaris-plugins/polaris-plugins-connector/connector-common/src/main/java/com/tencent/polaris/plugins/connector/common/constant/NacosConstant.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-common/src/main/java/com/tencent/polaris/plugins/connector/common/constant/NacosConstant.java
@@ -29,5 +29,13 @@ public interface NacosConstant {
         String NACOS_SERVICE_KEY = "nacos.service";
 
         String NACOS_WEIGHT_KEY = "nacos.weight";
+
+        String NACOS_DUBBO_ADAPT_KEY = "nacos.dubboAdapt";
+
+        String DUBBO_CATEGORY_KEY = "dubbo.category";
+
+        String DUBBO_VERSION_KEY = "dubbo.version";
+
+        String DUBBO_GROUP_KEY = "dubbo.group";
     }
 }

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosConnector.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosConnector.java
@@ -154,6 +154,9 @@ public class NacosConnector extends DestroyableServerConnector {
         if (metadata.containsKey(NACOS_WEIGHT_KEY)) {
             nacosContext.setNacosWeight(Double.parseDouble(metadata.get(NACOS_WEIGHT_KEY)));
         }
+        if (metadata.containsKey(NACOS_DUBBO_ADAPT_KEY)) {
+            nacosContext.setDubboAdapt(Boolean.parseBoolean(metadata.get(NACOS_DUBBO_ADAPT_KEY)));
+        }
         if (metadata.containsKey(PropertyKeyConst.NAMESPACE) && StringUtils.isNotEmpty(
                 metadata.get(PropertyKeyConst.NAMESPACE))) {
             nacosContext.setNamespace(metadata.get(PropertyKeyConst.NAMESPACE));
@@ -391,10 +394,17 @@ public class NacosConnector extends DestroyableServerConnector {
     }
 
     private String getServiceName(CommonProviderRequest req) {
-        // nacos上注册和polaris不同的服务名时优先用nacosContext中的serviceName
         String serviceName = req.getService();
         if (StringUtils.isNotEmpty(nacosContext.getServiceName())) {
             serviceName = nacosContext.getServiceName();
+        }
+        if (nacosContext.isDubboAdapt()) {
+            Map<String, String> metadata = Optional.ofNullable(req.getMetadata())
+                    .orElse(Collections.emptyMap());
+            String category = metadata.getOrDefault(DUBBO_CATEGORY_KEY, "providers");
+            String version  = metadata.getOrDefault(DUBBO_VERSION_KEY,  "");
+            String group    = metadata.getOrDefault(DUBBO_GROUP_KEY,    "");
+            serviceName = category + ":" + serviceName + ":" + version + ":" + group;
         }
         return serviceName;
     }

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosContext.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosContext.java
@@ -23,6 +23,11 @@ import static com.alibaba.nacos.api.common.Constants.DEFAULT_GROUP;
 import static com.alibaba.nacos.api.common.Constants.DEFAULT_NAMESPACE_ID;
 
 import com.tencent.polaris.api.config.global.ServerConnectorConfig;
+import com.tencent.polaris.api.utils.StringUtils;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Context of nacos server connector.
@@ -44,6 +49,14 @@ public class NacosContext {
     private Long nacosErrorSleep;
 
     private double nacosWeight;
+
+    private boolean dubboAdapt;
+
+    /**
+     * 发现侧 polaris 服务名 -> nacos 服务名映射表。
+     * 仅 dubboAdapt=true 时生效；未命中/空值透传原服务名。
+     */
+    private final Map<String, String> serviceNameMappings = new ConcurrentHashMap<>();
 
 
     public NacosContext(){
@@ -112,6 +125,63 @@ public class NacosContext {
         this.nacosWeight = nacosWeight;
     }
 
+    public boolean isDubboAdapt() {
+        return dubboAdapt;
+    }
+
+    public void setDubboAdapt(boolean dubboAdapt) {
+        this.dubboAdapt = dubboAdapt;
+    }
+
+    /**
+     * 注册一条服务名映射。polaris 名或 nacos 名为空（null/空串）时按移除处理。
+     *
+     * <p><b>重要:</b> 映射应在该 polaris 服务首次被订阅之前写入。一个 polaris 服务首次 watch
+     * 后,NacosService 会以转换后的 nacos 名为 key 缓存 EventListener;此时再修改映射不会
+     * 触发重订阅,也不会取消旧订阅。若确需切换订阅名,请显式 unsubscribe 后再 subscribe。
+     */
+    public void putServiceNameMapping(String polarisServiceName, String nacosServiceName) {
+        if (StringUtils.isEmpty(polarisServiceName)) {
+            return;
+        }
+        if (StringUtils.isEmpty(nacosServiceName)) {
+            serviceNameMappings.remove(polarisServiceName);
+        } else {
+            serviceNameMappings.put(polarisServiceName, nacosServiceName);
+        }
+    }
+
+    public void removeServiceNameMapping(String polarisServiceName) {
+        if (StringUtils.isNotEmpty(polarisServiceName)) {
+            serviceNameMappings.remove(polarisServiceName);
+        }
+    }
+
+    /**
+     * 整表替换。传入 null 等价于清空。key 或 value 为空（null/空串）的条目将被丢弃。
+     *
+     * <p>非原子操作(clear 后再 put),仅适合在连接器首次订阅之前做一次性初始化使用。
+     * 运行时动态增删映射请使用 {@link #putServiceNameMapping(String, String)}
+     * 与 {@link #removeServiceNameMapping(String)},避免读写端看到空表中间态。
+     */
+    public void setServiceNameMappings(Map<String, String> mappings) {
+        serviceNameMappings.clear();
+        if (mappings != null) {
+            for (Map.Entry<String, String> e : mappings.entrySet()) {
+                if (StringUtils.isNotEmpty(e.getKey()) && StringUtils.isNotEmpty(e.getValue())) {
+                    serviceNameMappings.put(e.getKey(), e.getValue());
+                }
+            }
+        }
+    }
+
+    /**
+     * 返回不可变视图，调用方修改将抛 UnsupportedOperationException。
+     */
+    public Map<String, String> getServiceNameMappings() {
+        return Collections.unmodifiableMap(serviceNameMappings);
+    }
+
     @Override
     public String toString() {
         return "NacosContext{" +
@@ -122,6 +192,7 @@ public class NacosContext {
                 ", serviceName='" + serviceName + '\'' +
                 ", nacosErrorSleep=" + nacosErrorSleep +
                 ", nacosWeight=" + nacosWeight +
+                ", dubboAdapt=" + dubboAdapt +
                 '}';
     }
 }

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosService.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/main/java/com/tencent/polaris/plugins/connector/nacos/NacosService.java
@@ -186,18 +186,32 @@ public class NacosService extends Destroyable {
         }
     }
 
+    private String resolveSubscribeName(ServiceUpdateTask task) {
+        String polarisName = task.getServiceEventKey().getService();
+        if (!nacosContext.isDubboAdapt()) {
+            return polarisName;
+        }
+        String mapped = nacosContext.getServiceNameMappings().get(polarisName);
+        if (StringUtils.isNotEmpty(mapped)) {
+            return mapped;
+        }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("[NacosConnector] dubboAdapt=true, no mapping for polaris service {}, "
+                    + "fallthrough to original name.", polarisName);
+        }
+        return polarisName;
+    }
+
     public void asyncGetInstances(ServiceUpdateTask serviceUpdateTask) {
         try {
-            EventListener nacosEventListener = eventListeners.get(serviceUpdateTask.getServiceEventKey().getService());
+            String subscribeName = resolveSubscribeName(serviceUpdateTask);
+            EventListener nacosEventListener = eventListeners.get(subscribeName);
             if (nacosEventListener == null) {
                 nacosEventListener = new NacosEventListener(serviceUpdateTask, nacosContext);
-                namingService.subscribe(serviceUpdateTask.getServiceEventKey().getService(), nacosContext.getGroupName(),
-                        nacosEventListener);
-                LOG.debug("[NacosConnector] Subscribe instances of {} success. ",
-                        serviceUpdateTask.getServiceEventKey().getService());
+                namingService.subscribe(subscribeName, nacosContext.getGroupName(), nacosEventListener);
+                eventListeners.put(subscribeName, nacosEventListener);  // 修复：补充 put，避免 doDestroy() unsubscribe 失效
+                LOG.debug("[NacosConnector] Subscribe instances of {} success.", subscribeName);
             }
-
-
         } catch (NacosException nacosException) {
             String errorMsg = String.format("subscribe nacos service instances of %s failed.",
                     serviceUpdateTask.getServiceEventKey().getService());

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/NacosConnectorTests.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/NacosConnectorTests.java
@@ -17,10 +17,215 @@
 
 package com.tencent.polaris.plugins.connector.nacos;
 
+import com.tencent.polaris.api.plugin.server.CommonProviderRequest;
+import com.tencent.polaris.api.plugin.server.ServerEvent;
+import com.tencent.polaris.api.pojo.ServiceEventKey;
+import com.tencent.polaris.api.pojo.ServiceKey;
+import com.tencent.polaris.plugins.connector.common.ServiceUpdateTask;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.tencent.polaris.plugins.connector.common.constant.NacosConstant.MetadataMapKey.DUBBO_CATEGORY_KEY;
+import static com.tencent.polaris.plugins.connector.common.constant.NacosConstant.MetadataMapKey.DUBBO_GROUP_KEY;
+import static com.tencent.polaris.plugins.connector.common.constant.NacosConstant.MetadataMapKey.DUBBO_VERSION_KEY;
+
+/**
+ * NacosConnector 单元测试
+ */
 public class NacosConnectorTests {
 
+    // ---- 注册侧 ----
 
+    /**
+     * dubboAdapt=false 时，服务名保持原样
+     */
+    @Test
+    public void getServiceName_dubboAdaptDisabled_returnsOriginal() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(false);
+
+        TestableNacosConnector connector = new TestableNacosConnector(ctx);
+
+        CommonProviderRequest req = buildProviderRequest("com.example.IFoo", null);
+        Assert.assertEquals("com.example.IFoo", connector.exposeGetServiceName(req));
+    }
+
+    /**
+     * dubboAdapt=true，metadata 仅有 interface（category/version/group 均使用默认值）
+     */
+    @Test
+    public void getServiceName_dubboAdaptEnabled_allDefaults() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(true);
+
+        TestableNacosConnector connector = new TestableNacosConnector(ctx);
+
+        CommonProviderRequest req = buildProviderRequest("com.example.IFoo", null);
+        Assert.assertEquals("providers:com.example.IFoo::", connector.exposeGetServiceName(req));
+    }
+
+    /**
+     * dubboAdapt=true，metadata 中指定了 category、version、group
+     */
+    @Test
+    public void getServiceName_dubboAdaptEnabled_allProvided() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(true);
+
+        TestableNacosConnector connector = new TestableNacosConnector(ctx);
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(DUBBO_CATEGORY_KEY, "consumers");
+        metadata.put(DUBBO_VERSION_KEY, "2.0.0");
+        metadata.put(DUBBO_GROUP_KEY, "groupB");
+        CommonProviderRequest req = buildProviderRequest("com.example.IFoo", metadata);
+        Assert.assertEquals("consumers:com.example.IFoo:2.0.0:groupB", connector.exposeGetServiceName(req));
+    }
+
+    /**
+     * dubboAdapt=true，nacosContext.serviceName 优先于 interface 名
+     */
+    @Test
+    public void getServiceName_dubboAdaptEnabled_serviceNameOverride() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(true);
+        ctx.setServiceName("overrideService");
+
+        TestableNacosConnector connector = new TestableNacosConnector(ctx);
+
+        CommonProviderRequest req = buildProviderRequest("com.example.IFoo", null);
+        // serviceName override 后 dubboAdapt 仍生效，以 overrideService 为 interface 部分
+        Assert.assertEquals("providers:overrideService::", connector.exposeGetServiceName(req));
+    }
+
+    // ---- 辅助方法 ----
+
+    private CommonProviderRequest buildProviderRequest(String service, Map<String, String> metadata) {
+        CommonProviderRequest req = new CommonProviderRequest();
+        req.setService(service);
+        req.setNamespace("default");
+        if (metadata != null) {
+            req.setMetadata(metadata);
+        }
+        return req;
+    }
+
+    // ---- 发现侧 ----
+
+    /**
+     * dubboAdapt=false，映射表即便有也不生效，返回原 polaris 服务名
+     */
+    @Test
+    public void resolveSubscribeName_dubboAdaptDisabled_returnsOriginal() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(false);
+        ctx.putServiceNameMapping("com.example.IFoo", "providers:com.example.IFoo:1.0.0:groupA");
+
+        TestableNacosService service = new TestableNacosService(ctx);
+
+        ServiceUpdateTask task = buildTask("com.example.IFoo");
+        Assert.assertEquals("com.example.IFoo", service.exposeResolveSubscribeName(task));
+    }
+
+    /**
+     * dubboAdapt=true，映射表为空，透传原名
+     */
+    @Test
+    public void resolveSubscribeName_dubboAdaptEnabled_emptyMappings_returnsOriginal() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(true);
+
+        TestableNacosService service = new TestableNacosService(ctx);
+
+        ServiceUpdateTask task = buildTask("com.example.IFoo");
+        Assert.assertEquals("com.example.IFoo", service.exposeResolveSubscribeName(task));
+    }
+
+    /**
+     * dubboAdapt=true，映射表中无该 polaris 名，透传原名
+     */
+    @Test
+    public void resolveSubscribeName_dubboAdaptEnabled_noMatch_returnsOriginal() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(true);
+        ctx.putServiceNameMapping("com.example.IOther", "providers:com.example.IOther:1.0.0:groupA");
+
+        TestableNacosService service = new TestableNacosService(ctx);
+
+        ServiceUpdateTask task = buildTask("com.example.IFoo");
+        Assert.assertEquals("com.example.IFoo", service.exposeResolveSubscribeName(task));
+    }
+
+    /**
+     * dubboAdapt=true，映射命中，返回映射值
+     */
+    @Test
+    public void resolveSubscribeName_dubboAdaptEnabled_hit_returnsMappedName() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(true);
+        ctx.putServiceNameMapping("com.example.IFoo", "providers:com.example.IFoo:1.0.0:groupA");
+
+        TestableNacosService service = new TestableNacosService(ctx);
+
+        ServiceUpdateTask task = buildTask("com.example.IFoo");
+        Assert.assertEquals("providers:com.example.IFoo:1.0.0:groupA",
+                service.exposeResolveSubscribeName(task));
+    }
+
+    /**
+     * dubboAdapt=true，通过 put(k, "") 移除后，回退到透传原名
+     */
+    @Test
+    public void resolveSubscribeName_dubboAdaptEnabled_emptyValueRemoved_returnsOriginal() {
+        NacosContext ctx = new NacosContext();
+        ctx.setDubboAdapt(true);
+        ctx.putServiceNameMapping("com.example.IFoo", "providers:com.example.IFoo:1.0.0:groupA");
+        ctx.putServiceNameMapping("com.example.IFoo", "");
+
+        TestableNacosService service = new TestableNacosService(ctx);
+
+        ServiceUpdateTask task = buildTask("com.example.IFoo");
+        Assert.assertEquals("com.example.IFoo", service.exposeResolveSubscribeName(task));
+    }
+
+    private ServiceUpdateTask buildTask(String service) {
+        ServiceKey sk = new ServiceKey("default", service);
+        ServiceEventKey eventKey = new ServiceEventKey(sk, ServiceEventKey.EventType.INSTANCE);
+        return new StubServiceUpdateTask(eventKey);
+    }
+
+    /**
+     * 测试用 ServiceUpdateTask stub，仅实现 getServiceEventKey()。
+     */
+    static class StubServiceUpdateTask extends ServiceUpdateTask {
+
+        private final ServiceEventKey eventKey;
+
+        public StubServiceUpdateTask(ServiceEventKey eventKey) {
+            super(null, null);
+            this.eventKey = eventKey;
+        }
+
+        @Override
+        public ServiceEventKey getServiceEventKey() {
+            return eventKey;
+        }
+
+        @Override
+        public void execute() {}
+
+        @Override
+        public void execute(ServiceUpdateTask task) {}
+
+        @Override
+        protected void handle(Throwable throwable) {}
+
+        @Override
+        public boolean notifyServerEvent(ServerEvent serverEvent) {
+            return false;
+        }
+    }
 }

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/NacosContextTest.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/NacosContextTest.java
@@ -1,0 +1,151 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.plugins.connector.nacos;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * NacosContext 服务名映射表单元测试。
+ */
+public class NacosContextTest {
+
+    @Test
+    public void putServiceNameMapping_storesEntry() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("A", "X");
+        Assert.assertEquals("X", ctx.getServiceNameMappings().get("A"));
+    }
+
+    @Test
+    public void putServiceNameMapping_nullPolarisName_ignored() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping(null, "X");
+        Assert.assertTrue(ctx.getServiceNameMappings().isEmpty());
+    }
+
+    @Test
+    public void putServiceNameMapping_emptyPolarisName_ignored() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("", "X");
+        Assert.assertTrue(ctx.getServiceNameMappings().isEmpty());
+    }
+
+    @Test
+    public void putServiceNameMapping_nullNacosName_removesEntry() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("A", "X");
+        ctx.putServiceNameMapping("A", null);
+        Assert.assertFalse(ctx.getServiceNameMappings().containsKey("A"));
+    }
+
+    @Test
+    public void putServiceNameMapping_emptyNacosName_removesEntry() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("A", "X");
+        ctx.putServiceNameMapping("A", "");
+        Assert.assertFalse(ctx.getServiceNameMappings().containsKey("A"));
+    }
+
+    @Test
+    public void removeServiceNameMapping_removesExistingEntry() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("A", "X");
+        ctx.removeServiceNameMapping("A");
+        Assert.assertFalse(ctx.getServiceNameMappings().containsKey("A"));
+    }
+
+    @Test
+    public void removeServiceNameMapping_nullKey_noException() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("A", "X");
+        ctx.removeServiceNameMapping(null);
+        Assert.assertTrue(ctx.getServiceNameMappings().containsKey("A"));
+    }
+
+    @Test
+    public void setServiceNameMappings_replacesAllEntries() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("A", "X");
+        Map<String, String> next = new HashMap<>();
+        next.put("B", "Y");
+        ctx.setServiceNameMappings(next);
+        Assert.assertFalse(ctx.getServiceNameMappings().containsKey("A"));
+        Assert.assertEquals("Y", ctx.getServiceNameMappings().get("B"));
+    }
+
+    @Test
+    public void setServiceNameMappings_filtersEmptyEntries() {
+        NacosContext ctx = new NacosContext();
+        Map<String, String> input = new HashMap<>();
+        input.put("A", "X");
+        input.put("B", "");
+        input.put("C", null);
+        input.put("", "Z");
+        // HashMap 允许一个 null key;这里故意选 HashMap 以覆盖 null-key 过滤分支
+        input.put(null, "W");
+        ctx.setServiceNameMappings(input);
+        Assert.assertEquals(1, ctx.getServiceNameMappings().size());
+        Assert.assertEquals("X", ctx.getServiceNameMappings().get("A"));
+    }
+
+    @Test
+    public void setServiceNameMappings_null_clearsTable() {
+        NacosContext ctx = new NacosContext();
+        ctx.putServiceNameMapping("A", "X");
+        ctx.setServiceNameMappings(null);
+        Assert.assertTrue(ctx.getServiceNameMappings().isEmpty());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void getServiceNameMappings_returnsUnmodifiableView() {
+        NacosContext ctx = new NacosContext();
+        ctx.getServiceNameMappings().put("A", "X");
+    }
+
+    @Test
+    public void concurrentPut_noLostWrites() throws Exception {
+        final NacosContext ctx = new NacosContext();
+        final int threads = 8;
+        final int perThread = 1000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            for (int t = 0; t < threads; t++) {
+                final int offset = t * perThread;
+                pool.submit(() -> {
+                    for (int i = 0; i < perThread; i++) {
+                        ctx.putServiceNameMapping("svc" + (offset + i), "nacos" + (offset + i));
+                    }
+                });
+            }
+            pool.shutdown();
+            Assert.assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS));
+        } finally {
+            if (!pool.isTerminated()) {
+                pool.shutdownNow();
+            }
+        }
+        Assert.assertEquals(threads * perThread, ctx.getServiceNameMappings().size());
+    }
+}

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/TestableNacosConnector.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/TestableNacosConnector.java
@@ -1,0 +1,52 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.plugins.connector.nacos;
+
+import com.tencent.polaris.api.plugin.server.CommonProviderRequest;
+
+import java.lang.reflect.Method;
+
+/**
+ * 测试辅助类，通过反射暴露 NacosConnector 的 package-private/private 方法。
+ */
+public class TestableNacosConnector extends NacosConnector {
+
+    public TestableNacosConnector(NacosContext nacosContext) {
+        // 将 nacosContext 注入父类（通过反射，因为字段为 private）
+        try {
+            java.lang.reflect.Field field = NacosConnector.class.getDeclaredField("nacosContext");
+            field.setAccessible(true);
+            field.set(this, nacosContext);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to inject nacosContext", e);
+        }
+    }
+
+    /**
+     * 暴露父类私有 getServiceName() 方法供测试使用。
+     */
+    public String exposeGetServiceName(CommonProviderRequest req) {
+        try {
+            Method method = NacosConnector.class.getDeclaredMethod("getServiceName", CommonProviderRequest.class);
+            method.setAccessible(true);
+            return (String) method.invoke(this, req);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke getServiceName", e);
+        }
+    }
+}

--- a/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/TestableNacosService.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-nacos/src/test/java/com/tencent/polaris/plugins/connector/nacos/TestableNacosService.java
@@ -1,0 +1,45 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.plugins.connector.nacos;
+
+import com.tencent.polaris.plugins.connector.common.ServiceUpdateTask;
+
+import java.lang.reflect.Method;
+
+/**
+ * 测试辅助类，通过反射暴露 NacosService 的 private 方法。
+ */
+public class TestableNacosService extends NacosService {
+
+    public TestableNacosService(NacosContext nacosContext) {
+        super(null, nacosContext);
+    }
+
+    /**
+     * 暴露私有 resolveSubscribeName() 方法供测试使用。
+     */
+    public String exposeResolveSubscribeName(ServiceUpdateTask task) {
+        try {
+            Method method = NacosService.class.getDeclaredMethod("resolveSubscribeName", ServiceUpdateTask.class);
+            method.setAccessible(true);
+            return (String) method.invoke(this, task);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to invoke resolveSubscribeName", e);
+        }
+    }
+}


### PR DESCRIPTION
## Describe what this PR does / why we need it

Adds Dubbo-adaptive service name mapping support to the Nacos connector, so that a Polaris service name can be transparently translated to a different Nacos service name when subscribing/querying from Nacos. This unblocks scenarios where Dubbo consumers registered in Polaris need to discover providers registered in Nacos under a different naming scheme.

### Key changes

- `NacosContext`
  - New `dubboAdapt` flag to enable the mapping behavior.
  - New `serviceNameMappings` (`ConcurrentHashMap<String, String>`): Polaris service name -> Nacos service name.
  - APIs: `putServiceNameMapping`, `removeServiceNameMapping`, `setServiceNameMappings` (bulk replace), `getServiceNameMappings` (unmodifiable view).
  - Empty key/value entries are treated as removals; bulk replace drops invalid entries.
- `NacosService` / `NacosConnector`: when `dubboAdapt=true`, resolve the Nacos service name via the mapping on subscribe/lookup paths; fall through to the original name when no mapping hit.
- `NacosConstant`: new constants used by the mapping logic.

### Notes on semantics

- Mappings should be populated **before** the first subscription for a given Polaris service. Once a service is watched, `NacosService` caches the `EventListener` under the resolved Nacos name; changing the mapping afterwards will not trigger re-subscription nor unsubscribe the old one. To switch names at runtime, callers should explicitly `unsubscribe` and then `subscribe` again.
- `setServiceNameMappings` is **not atomic** (clear + put). It is intended for one-shot initialization before first use. For runtime updates, use the single-entry `put`/`remove` methods.
- `getServiceNameMappings` returns an unmodifiable view.

### Tests

- Extended `NacosConnectorTests` with adaptive-mapping scenarios.
- New `NacosContextTest` covering put/remove/bulk-replace, empty-value semantics, and unmodifiable view.
- Introduced `TestableNacosConnector` / `TestableNacosService` to enable isolated testing of the adapt path.

## Which issue(s) this PR fixes

N/A

## Special notes for reviewer

- Behavior is fully gated by `dubboAdapt`; when disabled, the connector behaves exactly as before.
- No change to the public `ServerConnector` interface — mappings are configured directly on `NacosContext`.