### PR TITLE
fix: newer lane rules take precedence over older ones when priority is equal in TSF mode

### DIFF
--- a/polaris-plugins/polaris-plugins-router/router-lane/src/main/java/com/tencent/polaris/plugins/router/lane/LaneRuleContainer.java
+++ b/polaris-plugins/polaris-plugins-router/router-lane/src/main/java/com/tencent/polaris/plugins/router/lane/LaneRuleContainer.java
@@ -60,6 +60,8 @@ public class LaneRuleContainer {
                 rules.add(laneRule);
             }
         }
+        // TSF 场景下同优先级时新规则优先，非 TSF 场景下旧规则优先
+        boolean isTsf = groups.values().stream().anyMatch(g -> "tsf".equals(g.getName()));
         rules.sort((o1, o2) -> {
             // 主调泳道入口规则优先
             boolean b1 = LaneUtils.isTrafficEntry(groups.get(o1.getGroupName()), manager, caller);
@@ -74,8 +76,8 @@ public class LaneRuleContainer {
             if (priorityResult != 0) {
                 return priorityResult;
             }
-            // 比较创建时间，越早创建的规则优先级越高
-            return o1.getCtime().compareTo(o2.getCtime());
+            // 比较创建时间：TSF 场景下越晚创建的规则优先级越高（新规则优先），非 TSF 场景下越早创建的规则优先级越高
+            return isTsf ? o2.getCtime().compareTo(o1.getCtime()) : o1.getCtime().compareTo(o2.getCtime());
         });
     }
 


### PR DESCRIPTION
## 问题描述

泳道路由在规则排序时，三级排序为：流量入口 → 优先级 → 创建时间。当前 `ctime` 比较使用升序，导致同优先级时旧规则优先匹配。

在 TSF 场景下，期望行为是**新规则优先**（即后创建的规则覆盖旧规则）。

## 修改内容

在 `LaneRuleContainer` 构造函数中，排序前先检测当前 `groups` 是否为 TSF 模式（通过 `group.getName() == "tsf"` 判断，与 `LaneRouter#checkServiceInLane` 的判断逻辑一致）：

- **TSF 场景**：`ctime` 降序 → 新规则优先
- **非 TSF 场景**：`ctime` 升序 → 旧规则优先（维持原有行为）

## 变更文件

- `polaris-plugins/polaris-plugins-router/router-lane/src/main/java/com/tencent/polaris/plugins/router/lane/LaneRuleContainer.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)