### PR TITLE
feat: Add shaded Nacos client log appender to polaris

### DIFF
--- a/polaris-common/polaris-logging/src/main/resources/polaris-log4j.xml
+++ b/polaris-common/polaris-logging/src/main/resources/polaris-log4j.xml
@@ -83,6 +83,55 @@
         </layout>
     </appender>
 
+    <!-- Nacos shaded appenders -->
+    <appender name="NACOS_CONFIG_LOG_FILE" class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/nacos/config.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%-5p] [method:%l]%n%m%n%n"/>
+        </layout>
+    </appender>
+    <appender name="ASYNC_NACOS_CONFIG" class="org.apache.log4j.AsyncAppender">
+        <param name="BufferSize" value="1024"/>
+        <param name="Blocking" value="false"/>
+        <appender-ref ref="NACOS_CONFIG_LOG_FILE"/>
+    </appender>
+
+    <appender name="NACOS_REMOTE_LOG_FILE" class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/nacos/remote.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%-5p] [method:%l]%n%m%n%n"/>
+        </layout>
+    </appender>
+    <appender name="ASYNC_NACOS_REMOTE" class="org.apache.log4j.AsyncAppender">
+        <param name="BufferSize" value="1024"/>
+        <param name="Blocking" value="false"/>
+        <appender-ref ref="NACOS_REMOTE_LOG_FILE"/>
+    </appender>
+
+    <appender name="NACOS_NAMING_LOG_FILE" class="org.apache.log4j.RollingFileAppender">
+        <param name="File" value="${polaris.log.home}/nacos/naming.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern"
+                   value="[%d{yyyy-MM-dd HH:mm:ss:SSS}] [%-5p] [method:%l]%n%m%n%n"/>
+        </layout>
+    </appender>
+    <appender name="ASYNC_NACOS_NAMING" class="org.apache.log4j.AsyncAppender">
+        <param name="BufferSize" value="1024"/>
+        <param name="Blocking" value="false"/>
+        <appender-ref ref="NACOS_NAMING_LOG_FILE"/>
+    </appender>
+
     <logger name="com.tencent.polaris" additivity="false">
         <level value="${polaris.log.level:-INFO}"/>
         <appender-ref ref="POLARIS_LOG_FILE"/>
@@ -114,5 +163,31 @@
     <logger name="polaris-event" additivity="false">
         <level value="${polaris.event.log.level:-INFO}"/>
         <appender-ref ref="POLARIS_EVENT_LOG_FILE"/>
+    </logger>
+
+    <!-- Nacos shaded loggers -->
+    <logger name="shade.polaris.com.alibaba.nacos.client" additivity="false">
+        <level value="${nacos.config.log.level:-INFO}"/>
+        <appender-ref ref="ASYNC_NACOS_CONFIG"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.common.remote.client" additivity="false">
+        <level value="${nacos.config.log.level:-INFO}"/>
+        <appender-ref ref="ASYNC_NACOS_REMOTE"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.common.labels" additivity="false">
+        <level value="${nacos.config.log.level:-INFO}"/>
+        <appender-ref ref="ASYNC_NACOS_REMOTE"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.client.config" additivity="false">
+        <level value="${nacos.config.log.level:-INFO}"/>
+        <appender-ref ref="ASYNC_NACOS_CONFIG"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.client.naming" additivity="false">
+        <level value="${nacos.naming.log.level:-INFO}"/>
+        <appender-ref ref="ASYNC_NACOS_NAMING"/>
     </logger>
 </log4j:configuration>

--- a/polaris-common/polaris-logging/src/main/resources/polaris-log4j2.xml
+++ b/polaris-common/polaris-logging/src/main/resources/polaris-log4j2.xml
@@ -109,6 +109,64 @@
 
             <DefaultRolloverStrategy max="${sys:polaris.event.log.retain.count:-7}"/>
         </RollingFile>
+
+        <!-- Nacos shaded appenders -->
+        <RollingFile name="NACOS_CONFIG_LOG_FILE"
+                     fileName="${sys:polaris.log.home}/nacos/config.log"
+                     filePattern="${sys:polaris.log.home}/nacos/config.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="${sys:nacos.config.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:nacos.config.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <Async name="ASYNC_NACOS_CONFIG" bufferSize="1024" blocking="false">
+            <AppenderRef ref="NACOS_CONFIG_LOG_FILE"/>
+        </Async>
+
+        <RollingFile name="NACOS_REMOTE_LOG_FILE"
+                     fileName="${sys:polaris.log.home}/nacos/remote.log"
+                     filePattern="${sys:polaris.log.home}/nacos/remote.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="${sys:nacos.remote.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:nacos.remote.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <Async name="ASYNC_NACOS_REMOTE" bufferSize="1024" blocking="false">
+            <AppenderRef ref="NACOS_REMOTE_LOG_FILE"/>
+        </Async>
+
+        <RollingFile name="NACOS_NAMING_LOG_FILE"
+                     fileName="${sys:polaris.log.home}/nacos/naming.log"
+                     filePattern="${sys:polaris.log.home}/nacos/naming.log.%d{yyyy-MM-dd}.%i">
+            <PatternLayout>
+                <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</Pattern>
+            </PatternLayout>
+
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="${sys:nacos.naming.log.file.size:-10MB}"/>
+            </Policies>
+
+            <DefaultRolloverStrategy max="${sys:nacos.naming.log.retain.count:-7}"/>
+        </RollingFile>
+
+        <Async name="ASYNC_NACOS_NAMING" bufferSize="1024" blocking="false">
+            <AppenderRef ref="NACOS_NAMING_LOG_FILE"/>
+        </Async>
     </Appenders>
 
     <Loggers>
@@ -151,6 +209,37 @@
                 level="${sys:polaris.event.log.level:-info}"
                 additivity="false">
             <AppenderRef ref="POLARIS_EVENT_LOG_FILE"/>
+        </Logger>
+
+        <!-- Nacos shaded loggers -->
+        <Logger name="shade.polaris.com.alibaba.nacos.client"
+                level="${sys:nacos.config.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="ASYNC_NACOS_CONFIG"/>
+        </Logger>
+
+        <Logger name="shade.polaris.com.alibaba.nacos.common.remote.client"
+                level="${sys:nacos.config.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="ASYNC_NACOS_REMOTE"/>
+        </Logger>
+
+        <Logger name="shade.polaris.com.alibaba.nacos.common.labels"
+                level="${sys:nacos.config.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="ASYNC_NACOS_REMOTE"/>
+        </Logger>
+
+        <Logger name="shade.polaris.com.alibaba.nacos.client.config"
+                level="${sys:nacos.config.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="ASYNC_NACOS_CONFIG"/>
+        </Logger>
+
+        <Logger name="shade.polaris.com.alibaba.nacos.client.naming"
+                level="${sys:nacos.naming.log.level:-info}"
+                additivity="false">
+            <AppenderRef ref="ASYNC_NACOS_NAMING"/>
         </Logger>
     </Loggers>
 </Configuration>

--- a/polaris-common/polaris-logging/src/main/resources/polaris-logback.xml
+++ b/polaris-common/polaris-logging/src/main/resources/polaris-logback.xml
@@ -141,6 +141,79 @@
         <appender-ref ref="POLARIS_UPDATE_EVENT_LOG_FILE"/>
     </appender>
 
+    <!-- Nacos shaded appenders -->
+    <appender name="NACOS_CONFIG_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/nacos/config.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/nacos/config.log.%i</fileNamePattern>
+            <maxIndex>${nacos.config.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${nacos.config.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_NACOS_CONFIG" class="ch.qos.logback.classic.AsyncAppender">
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>1024</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="NACOS_CONFIG_LOG_FILE"/>
+    </appender>
+
+    <appender name="NACOS_REMOTE_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/nacos/remote.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/nacos/remote.log.%i</fileNamePattern>
+            <maxIndex>${nacos.remote.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${nacos.remote.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_NACOS_REMOTE" class="ch.qos.logback.classic.AsyncAppender">
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>1024</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="NACOS_REMOTE_LOG_FILE"/>
+    </appender>
+
+    <appender name="NACOS_NAMING_LOG_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${polaris.log.home}/nacos/naming.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${polaris.log.home}/nacos/naming.log.%i</fileNamePattern>
+            <maxIndex>${nacos.naming.log.retain.count:-7}</maxIndex>
+        </rollingPolicy>
+
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>${nacos.naming.log.file.size:-10MB}</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %p [%-5t:%c{2}] %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_NACOS_NAMING" class="ch.qos.logback.classic.AsyncAppender">
+        <discardingThreshold>0</discardingThreshold>
+        <queueSize>1024</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="NACOS_NAMING_LOG_FILE"/>
+    </appender>
+
     <logger name="com.tencent.polaris" level="${polaris.log.level:-info}"
             additivity="false">
         <appender-ref ref="POLARIS_LOG_FILE"/>
@@ -184,5 +257,36 @@
             level="${polaris.event.log.level:-info}"
             additivity="false">
         <appender-ref ref="POLARIS_EVENT_LOG_FILE"/>
+    </logger>
+
+    <!-- Nacos shaded loggers -->
+    <logger name="shade.polaris.com.alibaba.nacos.client"
+            level="${nacos.config.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="ASYNC_NACOS_CONFIG"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.common.remote.client"
+            level="${nacos.config.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="ASYNC_NACOS_REMOTE"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.common.labels"
+            level="${nacos.config.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="ASYNC_NACOS_REMOTE"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.client.config"
+            level="${nacos.config.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="ASYNC_NACOS_CONFIG"/>
+    </logger>
+
+    <logger name="shade.polaris.com.alibaba.nacos.client.naming"
+            level="${nacos.naming.log.level:-info}"
+            additivity="false">
+        <appender-ref ref="ASYNC_NACOS_NAMING"/>
     </logger>
 </configuration>


### PR DESCRIPTION
启用nacos北极星双注册时，shade nacos客户端会把日志打印在控制台。
在polaris-logging中添加了配置，让其保存在polaris/log/nacos下。
<img width="397" height="176" alt="Clipboard_Screenshot_1777624041" src="https://github.com/user-attachments/assets/0368b7fd-f337-41e0-ae5a-7cbdb63758ae" />
<img width="1361" height="401" alt="Clipboard_Screenshot_1777624055" src="https://github.com/user-attachments/assets/02b91469-f486-488c-ab68-fdfd813084ee" />

