### PR TITLE
feat: report version_name and omit ACK properties without conflicts

### DIFF
--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventAck.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventAck.java
@@ -26,7 +26,8 @@ import java.util.List;
  * <p>
  * 字段输出规则对齐 Go 端 client_event_ack：null 字段被省略（模拟 omitempty），
  * content 始终输出（未命中时为空串，供服务端区分"内容为空"与"未返回内容"）。
- * 加密文件的 properties 为 AES 密文字符串（与 content 同一把 data_key），非加密时为数组。
+ * 加密文件的 properties 为 AES 密文字符串（与 content 同一把 data_key），非加密时为数组；
+ * 仅在存在同名文件冲突或生效值被其他来源覆盖时输出，无冲突时省略。
  *
  * @author evelynwei
  */
@@ -40,6 +41,9 @@ class ClientEventAck {
 
     @SerializedName("version")
     private Long version;
+
+    @SerializedName("version_name")
+    private String versionName;
 
     @SerializedName("md5")
     private String md5;
@@ -96,6 +100,14 @@ class ClientEventAck {
 
     void setVersion(Long version) {
         this.version = version;
+    }
+
+    String getVersionName() {
+        return versionName;
+    }
+
+    void setVersionName(String versionName) {
+        this.versionName = versionName;
     }
 
     String getMd5() {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
@@ -183,9 +183,12 @@ public class ClientEventQueryHandler {
     }
 
     private void fillSnapshot(ClientEventAck ack, ConfigFileSnapshot snapshot, String publicKey) {
-        // 对齐 Go 的 omitempty:version/md5/effective_time 零值时省略字段
+        // 对齐 Go 的 omitempty: version/version_name/md5/effective_time 零值时省略字段
         if (snapshot.getVersion() > 0) {
             ack.setVersion(snapshot.getVersion());
+        }
+        if (snapshot.getVersionName() != null && !snapshot.getVersionName().isEmpty()) {
+            ack.setVersionName(snapshot.getVersionName());
         }
         if (snapshot.getMd5() != null && !snapshot.getMd5().isEmpty()) {
             ack.setMd5(snapshot.getMd5());
@@ -255,8 +258,9 @@ public class ClientEventQueryHandler {
     }
 
     /**
-     * 填充 properties。未注册 Provider 时保持 null，Gson 省略该字段，ACK 退化为与 Go 一致的形态。
-     * 单个 key 解析失败只降级该 key，不影响整体 applied=true。
+     * 填充 properties。服务端以该字段有无值判断是否存在配置冲突，因此仅在真正冲突时输出：
+     * 其他被监听文件存在同名 key，或生效值被其他来源覆盖（file_value 与 effective_value 不一致）。
+     * 无冲突时保持 null，Gson 省略该字段。未注册 Provider 时同样省略。
      * 加密文件：先组明文数组，再用快照 AES data_key 整体加密（与 content 同一把密钥、AES-CBC/IV=key[:16]），
      * ACK.properties 输出密文字符串；无密钥或加密失败则省略该字段，永不回传明文数组。
      */
@@ -280,21 +284,28 @@ public class ClientEventQueryHandler {
     private List<ClientEventAck.PropertyEntry> buildPropertyEntries(ConfigEffectiveValueProvider provider,
             List<String> keys, ConfigFileMetadata metadata) {
         List<ClientEventAck.PropertyEntry> entries = new ArrayList<>();
+        List<String> omittedKeys = new ArrayList<>();
         int serializedBytes = 2;
         for (String key : keys) {
             if (key != null) {
                 ClientEventAck.PropertyEntry entry = buildPropertyEntry(provider, key, metadata);
-                int entryBytes = gson.toJson(entry).getBytes(StandardCharsets.UTF_8).length;
-                int separatorBytes = entries.isEmpty() ? 0 : 1;
-                if (serializedBytes + separatorBytes + entryBytes > MAX_ACK_PROPERTIES_BYTES) {
-                    LOG.warn("[Config] ack properties truncated, file = {}, included = {}, total = {}, limit = {} bytes",
-                            metadata, entries.size(), keys.size(), MAX_ACK_PROPERTIES_BYTES);
-                    break;
+                boolean conflicted = hasConflict(entry);
+                if (conflicted) {
+                    int entryBytes = gson.toJson(entry).getBytes(StandardCharsets.UTF_8).length;
+                    int separatorBytes = entries.isEmpty() ? 0 : 1;
+                    if (serializedBytes + separatorBytes + entryBytes > MAX_ACK_PROPERTIES_BYTES) {
+                        LOG.warn("[Config] ack properties truncated, file = {}, included = {}, total = {}, limit = {} bytes",
+                                metadata, entries.size(), keys.size(), MAX_ACK_PROPERTIES_BYTES);
+                        break;
+                    }
+                    entries.add(entry);
+                    serializedBytes += separatorBytes + entryBytes;
+                } else {
+                    omittedKeys.add(key);
                 }
-                entries.add(entry);
-                serializedBytes += separatorBytes + entryBytes;
             }
         }
+        logPropertySelection(metadata, entries, omittedKeys);
         return entries;
     }
 
@@ -331,6 +342,35 @@ public class ClientEventQueryHandler {
             LOG.warn("[Config] resolve keys failed, file = {}", metadata);
             return null;
         }
+    }
+
+    private void logPropertySelection(ConfigFileMetadata metadata, List<ClientEventAck.PropertyEntry> entries,
+            List<String> omittedKeys) {
+        if (LOG.isDebugEnabled()) {
+            List<String> conflictedKeys = new ArrayList<>(entries.size());
+            for (ClientEventAck.PropertyEntry entry : entries) {
+                conflictedKeys.add(entry.getKey());
+            }
+            LOG.debug("[Config] ack properties, file = {}, conflicted = {}, omitted = {}",
+                    metadata, conflictedKeys, omittedKeys);
+        }
+    }
+
+    private boolean hasConflict(ClientEventAck.PropertyEntry entry) {
+        boolean conflicted = false;
+        List<ClientEventAck.ConflictEntry> conflicts = entry.getConflicts();
+        if (conflicts != null && !conflicts.isEmpty()) {
+            conflicted = true;
+        } else {
+            String fileValue = entry.getFileValue();
+            String effectiveValue = entry.getEffectiveValue();
+            if (fileValue == null) {
+                conflicted = effectiveValue != null;
+            } else {
+                conflicted = !fileValue.equals(effectiveValue);
+            }
+        }
+        return conflicted;
     }
 
     private ClientEventAck.PropertyEntry buildPropertyEntry(ConfigEffectiveValueProvider provider, String key,

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
@@ -252,6 +252,10 @@ public class ConfigFilePersistentHandler {
             resConfigFile.setContent(jsonMap.get("content").toString());
             resConfigFile.setMd5(jsonMap.get("md5").toString());
             resConfigFile.setVersion(Long.valueOf(String.valueOf(jsonMap.get("version"))));
+            Object name = jsonMap.get("name");
+            if (name != null) {
+                resConfigFile.setName(name.toString());
+            }
             Object sourceContent = jsonMap.get("sourceContent");
             if (sourceContent != null) {
                 resConfigFile.setSourceContent(sourceContent.toString());

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshot.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshot.java
@@ -17,14 +17,18 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+import com.tencent.polaris.api.plugin.configuration.ConfigFile;
+
 /**
- * ConfigFile 版本、MD5、内容与生效时间的不可变快照，保证四者来自同一份配置对象。
+ * ConfigFile 版本、版本名、MD5、内容与生效时间的不可变快照，保证字段来自同一份配置对象。
  *
  * @author fishtailfu
  */
 public class ConfigFileSnapshot {
 
     private final long version;
+
+    private final String versionName;
 
     private final String md5;
 
@@ -42,9 +46,21 @@ public class ConfigFileSnapshot {
         this(version, md5, content, effectiveTime, false, null, null);
     }
 
+    public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime, String versionName) {
+        this.version = version;
+        this.versionName = versionName;
+        this.md5 = md5;
+        this.content = content;
+        this.effectiveTime = effectiveTime;
+        this.encrypted = false;
+        this.encryptAlgo = null;
+        this.dataKey = null;
+    }
+
     public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime, boolean encrypted,
             String encryptAlgo, String dataKey) {
         this.version = version;
+        this.versionName = null;
         this.md5 = md5;
         this.content = content;
         this.effectiveTime = effectiveTime;
@@ -53,8 +69,30 @@ public class ConfigFileSnapshot {
         this.dataKey = dataKey;
     }
 
+    /**
+     * 从同一份本地 ConfigFile 构造快照，version/versionName/md5 与加密字段同源。
+     *
+     * @param configFile 本地配置
+     * @param content ACK/上报使用的源内容
+     * @param effectiveTime 生效时间戳
+     */
+    public ConfigFileSnapshot(ConfigFile configFile, String content, long effectiveTime) {
+        this.version = configFile.getVersion();
+        this.versionName = configFile.getName();
+        this.md5 = configFile.getMd5();
+        this.content = content;
+        this.effectiveTime = effectiveTime;
+        this.encrypted = configFile.isEncrypted();
+        this.encryptAlgo = configFile.getEncryptAlgo();
+        this.dataKey = configFile.getDataKey();
+    }
+
     public long getVersion() {
         return version;
+    }
+
+    public String getVersionName() {
+        return versionName;
     }
 
     public String getMd5() {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigWatchInfo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigWatchInfo.java
@@ -17,6 +17,8 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+import com.google.gson.annotations.SerializedName;
+
 /**
  * 配置监听画像中的单个监听项快照。
  *
@@ -32,14 +34,19 @@ public class ConfigWatchInfo {
 
     private final long version;
 
+    @SerializedName("version_name")
+    private final String versionName;
+
     private final String md5;
 
-    public ConfigWatchInfo(String namespace, String group, String fileName, long version, String md5) {
+    public ConfigWatchInfo(String namespace, String group, String fileName, long version, String md5,
+            String versionName) {
         this.namespace = namespace;
         this.group = group;
         this.fileName = fileName;
         this.version = version;
         this.md5 = md5;
+        this.versionName = versionName;
     }
 
     public String getNamespace() {
@@ -56,6 +63,10 @@ public class ConfigWatchInfo {
 
     public long getVersion() {
         return version;
+    }
+
+    public String getVersionName() {
+        return versionName;
     }
 
     public String getMd5() {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigWatchReportRequestCustomizer.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigWatchReportRequestCustomizer.java
@@ -107,18 +107,21 @@ public class ConfigWatchReportRequestCustomizer implements ReportClientRequestCu
             ConfigFileMetadata metadata = entry.getKey();
             RemoteConfigFileRepo repo = entry.getValue();
             ConfigFileSnapshot snapshot = repo.getSnapshot();
-            String md5 = snapshot == null ? "" : snapshot.getMd5();
-            if (md5 == null) {
-                md5 = "";
-            }
+            String md5 = emptyIfMissing(snapshot == null ? null : snapshot.getMd5());
+            String versionName = emptyIfMissing(snapshot == null ? null : snapshot.getVersionName());
             watchList.add(new ConfigWatchInfo(
                     metadata.getNamespace(),
                     metadata.getFileGroup(),
                     metadata.getFileName(),
                     snapshot == null ? 0 : snapshot.getVersion(),
-                    md5));
+                    md5,
+                    versionName));
         }
         return gson.toJson(java.util.Collections.singletonMap("config_watch", watchList));
+    }
+
+    private String emptyIfMissing(String value) {
+        return value == null ? "" : value;
     }
 
     @Override

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
@@ -148,10 +148,10 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
     }
 
     /**
-     * 一次性读取当前版本、MD5、源内容与生效时间。content 取源内容（sourceContent，加密配置为密文），
+     * 一次性读取当前版本、版本名、MD5、源内容与生效时间。content 取源内容（sourceContent，加密配置为密文），
      * 与 md5（源内容摘要）自洽且不回传解密明文；非加密配置源内容为空时回退 content。
      *
-     * @return 包含 version、md5、content、effectiveTime 的快照
+     * @return 包含 version、versionName、md5、content、effectiveTime 的快照
      */
     public ConfigFileSnapshot getSnapshot() {
         synchronized (snapshotLock) {
@@ -163,9 +163,7 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
             if (content == null) {
                 content = configFile.isEncrypted() ? "" : configFile.getContent();
             }
-            return new ConfigFileSnapshot(configFile.getVersion(), configFile.getMd5(), content,
-                    effectiveTime.get(), configFile.isEncrypted(), configFile.getEncryptAlgo(),
-                    configFile.getDataKey());
+            return new ConfigFileSnapshot(configFile, content, effectiveTime.get());
         }
     }
 

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
@@ -88,19 +88,23 @@ public class ClientEventQueryHandlerTest {
     }
 
     /**
-     * 测试目的：合法 config 查询且文件已监听时，返回 applied=true 且带 version/md5/content/effective_time。
+     * 测试目的：合法 config 查询且文件已监听时，返回 applied=true 且带 version/version_name/md5/content。
      * 测试场景：注册监听文件后查询。
-     * 验证内容：applied、version、md5、content、effective_time、无 reason、无 properties。
+     * 验证内容：applied、version、version_name、md5、content、effective_time、无 reason、无 properties。
      */
     @Test
     public void testHandleConfigQuerySuccess() {
-        registerWatched("ns", "g", "f.yaml", "server:\n  port: 8080", 12, "md5abc", 1785900000000L);
+        RemoteConfigFileRepo repo = registerWatched("ns", "g", "f.yaml", "server:\n  port: 8080", 12, "md5abc",
+                1785900000000L);
+        when(repo.getSnapshot()).thenReturn(new ConfigFileSnapshot(12, "md5abc", "server:\n  port: 8080",
+                1785900000000L, "v1.0.0"));
 
         JsonObject ack = ackOf(handler.onPush(1, pushJson("ns", "g", "f.yaml")));
 
         assertThat(ack.get("applied").getAsBoolean()).isTrue();
         assertThat(ack.get("kind").getAsString()).isEqualTo("config");
         assertThat(ack.get("version").getAsLong()).isEqualTo(12);
+        assertThat(ack.get("version_name").getAsString()).isEqualTo("v1.0.0");
         assertThat(ack.get("md5").getAsString()).isEqualTo("md5abc");
         assertThat(ack.get("effective_time").getAsLong()).isEqualTo(1785900000000L);
         assertThat(ack.get("content").getAsString()).isEqualTo("server:\n  port: 8080");
@@ -422,7 +426,13 @@ public class ClientEventQueryHandlerTest {
             }
             return new EffectiveValue(largeValue, largeValue, "test");
         });
-        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        when(provider.resolveConflicts(any(String.class), any())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0);
+            if ("small".equals(key)) {
+                return Collections.singletonList(new ConfigKeyConflict("ns", "g", "other.yaml", "value"));
+            }
+            return Collections.singletonList(new ConfigKeyConflict("ns", "g", "other.yaml", largeValue));
+        });
         handler.registerProvider(provider);
 
         String ackJson = handler.onPush(1, pushJson("ns", "g", "f.yaml"));
@@ -435,9 +445,55 @@ public class ClientEventQueryHandlerTest {
     }
 
     /**
+     * 测试目的：无同名文件冲突且 file_value 与 effective_value 一致时省略 properties。
+     * 测试场景：Provider 返回单 key，conflicts 为空，两端值相同。
+     * 验证内容：ACK 无 properties 字段。
+     */
+    @Test
+    public void testPropertiesOmittedWhenNoConflict() {
+        registerWatched("ns", "g", "f.yaml", "aaa.bbb=123", 12, "md5abc", 1785900000000L);
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("aaa.bbb"));
+        when(provider.resolve(any(String.class), any()))
+                .thenReturn(new EffectiveValue("123", "123", "polaris:ns/g/f.yaml"));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        JsonObject ack = ackOf(handler.onPush(1, pushJson("ns", "g", "f.yaml")));
+
+        assertThat(ack.get("applied").getAsBoolean()).isTrue();
+        assertThat(ack.has("properties")).isFalse();
+    }
+
+    /**
+     * 测试目的：生效值被其他来源覆盖时仍输出 properties。
+     * 测试场景：conflicts 为空，但 file_value 与 effective_value 不同。
+     * 验证内容：properties 含该 key 及覆盖后的生效值。
+     */
+    @Test
+    public void testPropertiesPresentWhenEffectiveValueOverridden() {
+        registerWatched("ns", "g", "f.yaml", "server.port=8080", 12, "md5abc", 1785900000000L);
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("server.port"));
+        when(provider.resolve(any(String.class), any()))
+                .thenReturn(new EffectiveValue("8080", "9090", "commandLineArgs"));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        JsonObject ack = ackOf(handler.onPush(1, pushJson("ns", "g", "f.yaml")));
+
+        assertThat(ack.get("applied").getAsBoolean()).isTrue();
+        JsonObject prop = ack.getAsJsonArray("properties").get(0).getAsJsonObject();
+        assertThat(prop.get("key").getAsString()).isEqualTo("server.port");
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("8080");
+        assertThat(prop.get("effective_value").getAsString()).isEqualTo("9090");
+        assertThat(prop.getAsJsonArray("conflicts")).isEmpty();
+    }
+
+    /**
      * 测试目的：Provider 单 key 解析抛异常时该 key 降级，整体仍 applied=true。
-     * 测试场景：resolve 抛异常。
-     * 验证内容：applied=true、properties 元素无 effective_value。
+     * 测试场景：resolve 抛异常且无文件冲突。
+     * 验证内容：applied=true，无 properties。
      */
     @Test
     public void testProviderResolveFailureDegradesSingleKey() {
@@ -451,14 +507,13 @@ public class ClientEventQueryHandlerTest {
         JsonObject ack = ackOf(handler.onPush(1, pushJson("ns", "g", "f.yaml")));
 
         assertThat(ack.get("applied").getAsBoolean()).isTrue();
-        JsonObject prop = ack.getAsJsonArray("properties").get(0).getAsJsonObject();
-        assertThat(prop.has("effective_value")).isFalse();
+        assertThat(ack.has("properties")).isFalse();
     }
 
     /**
-     * 测试目的：Provider 返回含 null 的冲突列表时不影响整体 ACK。
-     * 测试场景：resolveConflicts 返回一个 null 元素。
-     * 验证内容：applied=true，conflicts 输出空数组。
+     * 测试目的：Provider 返回含 null 的冲突列表时视为无冲突。
+     * 测试场景：resolveConflicts 返回一个 null 元素，file_value 与 effective_value 相同。
+     * 验证内容：applied=true，无 properties。
      */
     @Test
     public void testNullConflictIsIgnored() {
@@ -473,8 +528,7 @@ public class ClientEventQueryHandlerTest {
         JsonObject ack = ackOf(handler.onPush(1, pushJson("ns", "g", "f.yaml")));
 
         assertThat(ack.get("applied").getAsBoolean()).isTrue();
-        JsonObject prop = ack.getAsJsonArray("properties").get(0).getAsJsonObject();
-        assertThat(prop.getAsJsonArray("conflicts")).isEmpty();
+        assertThat(ack.has("properties")).isFalse();
     }
 
     /**
@@ -557,6 +611,7 @@ public class ClientEventQueryHandlerTest {
         assertThat(ack.get("version").getAsLong()).isEqualTo(2L);
         assertThat(ack.has("md5")).isFalse();
         assertThat(ack.has("effective_time")).isFalse();
+        assertThat(ack.has("version_name")).isFalse();
         assertThat(ack.get("content").getAsString()).isEmpty();
     }
 
@@ -574,6 +629,7 @@ public class ClientEventQueryHandlerTest {
         assertThat(ack.get("applied").getAsBoolean()).isTrue();
         assertThat(ack.has("version")).isFalse();
         assertThat(ack.has("md5")).isFalse();
+        assertThat(ack.has("version_name")).isFalse();
     }
 
     /**

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshotTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshotTest.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+import com.tencent.polaris.api.plugin.configuration.ConfigFile;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,15 +30,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ConfigFileSnapshotTest {
 
     /**
-     * 测试目的：四元组快照各字段可读且不可变。
-     * 测试场景：构造含 version/md5/content/effectiveTime 的快照。
-     * 验证内容：四个 getter 返回构造值。
+     * 测试目的：快照各字段可读且不可变。
+     * 测试场景：构造含 version/versionName/md5/content/effectiveTime 的快照。
+     * 验证内容：getter 返回构造值。
      */
     @Test
     public void testSnapshotFields() {
-        ConfigFileSnapshot snapshot = new ConfigFileSnapshot(12, "md5abc", "k=v", 1785900000000L);
+        ConfigFileSnapshot snapshot = new ConfigFileSnapshot(12, "md5abc", "k=v", 1785900000000L, "v1.0.0");
 
         assertThat(snapshot.getVersion()).isEqualTo(12);
+        assertThat(snapshot.getVersionName()).isEqualTo("v1.0.0");
         assertThat(snapshot.getMd5()).isEqualTo("md5abc");
         assertThat(snapshot.getContent()).isEqualTo("k=v");
         assertThat(snapshot.getEffectiveTime()).isEqualTo(1785900000000L);
@@ -53,8 +55,36 @@ public class ConfigFileSnapshotTest {
         ConfigFileSnapshot snapshot = new ConfigFileSnapshot(0, "", null, 0);
 
         assertThat(snapshot.getVersion()).isZero();
+        assertThat(snapshot.getVersionName()).isNull();
         assertThat(snapshot.getMd5()).isEmpty();
         assertThat(snapshot.getContent()).isNull();
         assertThat(snapshot.getEffectiveTime()).isZero();
+    }
+
+    /**
+     * 测试目的：从 ConfigFile 构造时 version/versionName/md5/加密字段同源。
+     * 测试场景：ConfigFile 同时设置发布名与加密字段。
+     * 验证内容：快照 getter 与 ConfigFile 一致。
+     */
+    @Test
+    public void testSnapshotFromConfigFile() {
+        ConfigFile configFile = new ConfigFile("ns", "g", "f");
+        configFile.setVersion(9);
+        configFile.setName("release-9");
+        configFile.setMd5("md5fromfile");
+        configFile.setEncrypted(true);
+        configFile.setEncryptAlgo("AES");
+        configFile.setDataKey("key");
+
+        ConfigFileSnapshot snapshot = new ConfigFileSnapshot(configFile, "cipher", 123L);
+
+        assertThat(snapshot.getVersion()).isEqualTo(9);
+        assertThat(snapshot.getVersionName()).isEqualTo("release-9");
+        assertThat(snapshot.getMd5()).isEqualTo("md5fromfile");
+        assertThat(snapshot.getContent()).isEqualTo("cipher");
+        assertThat(snapshot.getEffectiveTime()).isEqualTo(123L);
+        assertThat(snapshot.isEncrypted()).isTrue();
+        assertThat(snapshot.getEncryptAlgo()).isEqualTo("AES");
+        assertThat(snapshot.getDataKey()).isEqualTo("key");
     }
 }

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigWatchReportRequestCustomizerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigWatchReportRequestCustomizerTest.java
@@ -43,10 +43,15 @@ public class ConfigWatchReportRequestCustomizerTest {
 
     private RemoteConfigFileRepo mockRepo(String namespace, String group, String fileName,
                                           long version, String md5) {
+        return mockRepo(namespace, group, fileName, version, md5, "");
+    }
+
+    private RemoteConfigFileRepo mockRepo(String namespace, String group, String fileName,
+                                          long version, String md5, String versionName) {
         RemoteConfigFileRepo repo = mock(RemoteConfigFileRepo.class);
         ConfigFileMetadata metadata = new DefaultConfigFileMetadata(namespace, group, fileName);
         when(repo.getConfigFileMetadata()).thenReturn(metadata);
-        when(repo.getSnapshot()).thenReturn(new ConfigFileSnapshot(version, md5, null, 0));
+        when(repo.getSnapshot()).thenReturn(new ConfigFileSnapshot(version, md5, null, 0, versionName));
         return repo;
     }
 
@@ -91,7 +96,7 @@ public class ConfigWatchReportRequestCustomizerTest {
     public void testCustomizeSingleFile() throws Exception {
         enableCustomizer();
         customizer.register(mockRepo("default", "scg-test", "application.yaml", 3,
-                "e10adc3949ba59abbe56e057f20f883e"));
+                "e10adc3949ba59abbe56e057f20f883e", "v1.0.6"));
 
         ReportClientRequest request = new ReportClientRequest();
         customizer.customize(request);
@@ -102,6 +107,7 @@ public class ConfigWatchReportRequestCustomizerTest {
         assertThat(json).contains("scg-test");
         assertThat(json).contains("application.yaml");
         assertThat(json).contains("\"version\":3");
+        assertThat(json).contains("\"version_name\":\"v1.0.6\"");
         assertThat(json).contains("e10adc3949ba59abbe56e057f20f883e");
     }
 
@@ -144,6 +150,7 @@ public class ConfigWatchReportRequestCustomizerTest {
 
         assertThat(request.getConfigMetadata()).contains("\"version\":0");
         assertThat(request.getConfigMetadata()).contains("\"md5\":\"\"");
+        assertThat(request.getConfigMetadata()).contains("\"version_name\":\"\"");
     }
 
     /**

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
@@ -83,6 +83,8 @@ public class RemoteConfigFileRepoTest {
         long version = 100;
         configFile.setContent(content);
         configFile.setVersion(version);
+        configFile.setName("v1.0.0");
+        configFile.setMd5("md5abc");
         ConfigFileResponse configFileResponse = new ConfigFileResponse(ServerCodes.EXECUTE_SUCCESS, "", configFile);
 
         when(configFileFilterChain.execute(any(), any())).thenReturn(configFileResponse);
@@ -96,6 +98,10 @@ public class RemoteConfigFileRepoTest {
 
         Assert.assertEquals(content, remoteConfigFileRepo.getContent());
         Assert.assertEquals(version, remoteConfigFileRepo.getConfigFileVersion());
+        ConfigFileSnapshot snapshot = remoteConfigFileRepo.getSnapshot();
+        assertThat(snapshot.getVersion()).isEqualTo(version);
+        assertThat(snapshot.getVersionName()).isEqualTo("v1.0.0");
+        assertThat(snapshot.getMd5()).isEqualTo("md5abc");
     }
 
     /**


### PR DESCRIPTION
# PR: feat: report version_name and omit ACK properties without conflicts

> 目标分支：`main` ← `feat/config_version_name`
> 上游仓库：`polarismesh/polaris-java`
> 创建命令：`gh pr create --repo polarismesh/polaris-java --base main --head peerless1024:feat/config_version_name --title "..." --body "$(cat 本文件 ## Summary 起)"`
> 关联：TAPD story `1020373952125434092`；前置 PR #721（配置生效查询）
> 当前 HEAD：`2cdd714f`

---

## Summary

- 配置监听上报（`config_watch`）与生效 ACK 均携带 `version_name`，取值与 `version`/`md5` 同一份本地快照。
- 服务端以 ACK `properties` 有无值作为「是否存在配置冲突」的信号：仅在同名 key 跨文件冲突、或生效值被其他来源覆盖时输出；无冲突时省略该字段（加密文件亦不回传空数组密文）。
- 每个 ACK 打一条 DEBUG：只列冲突 / 省略的 key 名，不打 value，便于加密 properties 排查。

## 背景与动机

#721 落地后，控制台仍有两类偏差：

1. **发布版本名缺失**：监听上报与生效 ACK 只有 `version`/`md5`，控制台无法把客户端快照对上具体 release 名。
2. **无冲突也被当成冲突**：Provider 注册后，ACK 总会带上 `properties`（哪怕 `file_value == effective_value` 且 `conflicts` 为空）。服务端把该字段有无值当作冲突开关，导致控制台误报「配置生效与实际生效不符」。

本 PR 只改 polaris-configuration-client 内部实现，不动公开 `-api`。

## 工作原理

```
本地 ConfigFile  ──getSnapshot()──►  ConfigFileSnapshot
     │                               version / version_name / md5 / content / encrypt*
     ├─ 画像上报 ConfigWatchInfo.version_name
     └─ 生效 ACK ClientEventAck.version_name（空串/零值省略，对齐 Go omitempty）

properties 输出规则：
  有 conflicts[]            → 输出该 key
  file_value ≠ effective_value → 输出该 key（含一侧为 null）
  其余                      → 不进入数组；数组为空则整字段省略
```

- `version_name` 来自 `ConfigFile.getName()`；落盘恢复时一并读 `name`，避免重启后快照缺发布名。
- 加密文件仍先组明文冲突数组，再用与 `content` 同一把 AES `data_key` 整段加密；无冲突则 `properties` 为 null，Gson 省略，永不把「空数组」加密后发出去。
- DEBUG 每 ACK 一条：`ack properties, file = ..., conflicted = [...], omitted = [...]`。

## 改动清单

| 文件 | 改动 |
|------|------|
| `ConfigFileSnapshot` | 增加 `versionName`；新增从 `ConfigFile` 构造的同源快照 |
| `RemoteConfigFileRepo` | `getSnapshot()` 走同源构造，带上 `name` 与加密字段 |
| `ConfigFilePersistentHandler` | 本地缓存读取 `name` |
| `ConfigWatchInfo` / `ConfigWatchReportRequestCustomizer` | 上报 JSON 增加 `version_name`（缺失时输出 `""`） |
| `ClientEventAck` / `ClientEventQueryHandler` | ACK 增加 `version_name`；`hasConflict` 过滤 properties；汇总 DEBUG |
| 对应 `*Test` | 覆盖同源快照、上报/ACK 字段、无冲突省略、覆盖冲突仍输出、截断只计冲突项 |

## 影响面

- 仅 `polaris-configuration-client` 内部类与单测；无 `-api` / SPI / 配置项 / BOM 变更。
- `ConfigFileSnapshot` 新增构造函数，类仍为 `internal`，下游不直接依赖。
- 行为变化：无冲突时 ACK **不再出现** `properties`（含加密密文）。依赖「只要注册了 Provider 就一定有 properties」的消费方需要改为：无该字段 = 无冲突。

## Test plan

- [ ] `mvn test -pl polaris-configuration/polaris-configuration-client -am -DfailIfNoTests=false`
- [ ] 画像上报 JSON 含 `version_name`，与本地快照一致；未拉取时为 `""`
- [ ] 生效 ACK：`version_name` 非空才输出；零值/`md5` 空时仍 omitempty
- [ ] `file_value == effective_value` 且 `conflicts` 为空时，ACK **无** `properties`
- [ ] 生效值被覆盖或跨文件同名 key 时，ACK **有** `properties`；加密文件仍与 `content` 同一把 `data_key`
- [ ] DEBUG 打开后，实例 override 场景可从 `omitted` / `conflicted` 判断 `test.secret.key` 是否被过滤

## 回滚策略

- 回退本提交即可；开关与事件流行为不变。
- 若需临时恢复「全量 properties」，去掉 `hasConflict` 过滤即可，`version_name` 可独立保留。

## 检查清单

- [x] Conventional Commits + `Signed-off-by`（DCO）+ `Co-Authored-By`
- [ ] Checkstyle
- [x] 未使用 Java 8 以上 API
- [x] 未手工编辑 `.flattened-pom.xml`
- [x] 日志不包含配置 value
