### PR TITLE
fix: guard null notifier to avoid NPE on stale file cache with concurrent remote update。

### DIFF
--- a/polaris-plugins/polaris-plugins-registry/registry-memory/src/main/java/com/tencent/polaris/plugins/registry/memory/CacheObject.java
+++ b/polaris-plugins/polaris-plugins-registry/registry-memory/src/main/java/com/tencent/polaris/plugins/registry/memory/CacheObject.java
@@ -146,9 +146,13 @@ public class CacheObject implements EventHandler {
     /**
      * 增加监听器
      *
-     * @param notifier 实例事件监听器
+     * @param notifier 实例事件监听器，允许为 null（表示仅触发远程注册、无需回调通知）
      */
     public void addNotifier(EventCompleteNotifier notifier) {
+        // notifier 为 null 时，仅用于触发远程注册，无需加入监听列表，也无需立即通知
+        if (notifier == null) {
+            return;
+        }
         if (checkNotifyNow(notifier)) {
             return;
         }

--- a/polaris-plugins/polaris-plugins-registry/registry-memory/src/main/java/com/tencent/polaris/plugins/registry/memory/InMemoryRegistry.java
+++ b/polaris-plugins/polaris-plugins-registry/registry-memory/src/main/java/com/tencent/polaris/plugins/registry/memory/InMemoryRegistry.java
@@ -220,7 +220,11 @@ public class InMemoryRegistry extends Destroyable implements LocalRegistry {
             CacheObject cacheObject = loadFileCache(svcEventKey);
             // 磁盘文件可用，直接通知invoker, 同时注册远程任务
             if (null != cacheObject && cacheObject.isRemoteUpdated()) {
-                notifier.complete(svcEventKey);
+                // notifier 允许为 null（外部可能直接以 null 调用），判空避免 NPE
+                if (notifier != null) {
+                    notifier.complete(svcEventKey);
+                }
+                // 传 null 表示仅需注册远程订阅，无需再通知任何监听器
                 loadRemoteValue(svcEventKey, null);
                 return;
             }
@@ -286,8 +290,10 @@ public class InMemoryRegistry extends Destroyable implements LocalRegistry {
         checkDestroyed();
         // 使用统一的方法来获取或创建CacheObject，确保并发安全
         CacheObject cacheObject = addOrGetCacheObject(svcEventKey, null);
-        //添加监听器
-        cacheObject.addNotifier(notifier);
+        // notifier 为 null 表示调用方已自行完成通知，这里只需确保远程订阅注册，无需再添加监听器
+        if (notifier != null) {
+            cacheObject.addNotifier(notifier);
+        }
         //触发往serverConnector注册
         if (cacheObject.startRegister()) {
             LOG.info("[LocalRegistry]start to register service handler for {}", svcEventKey);

--- a/polaris-plugins/polaris-plugins-registry/registry-memory/src/test/java/com/tencent/polaris/plugins/registry/memory/CacheObjectTest.java
+++ b/polaris-plugins/polaris-plugins-registry/registry-memory/src/test/java/com/tencent/polaris/plugins/registry/memory/CacheObjectTest.java
@@ -1,0 +1,171 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.plugins.registry.memory;
+
+import com.tencent.polaris.api.plugin.registry.CacheHandler;
+import com.tencent.polaris.api.plugin.registry.EventCompleteNotifier;
+import com.tencent.polaris.api.pojo.RegistryCacheValue;
+import com.tencent.polaris.api.pojo.ServiceEventKey;
+import com.tencent.polaris.api.pojo.ServiceEventKey.EventType;
+import com.tencent.polaris.api.pojo.ServiceKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link CacheObject}.
+ *
+ * @author hewei
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CacheObjectTest {
+
+    private static final String TEST_NAMESPACE = "TestNamespace";
+
+    private static final String TEST_SERVICE = "TestService";
+
+    @Mock
+    private CacheHandler cacheHandler;
+
+    @Mock
+    private InMemoryRegistry registry;
+
+    private ServiceEventKey svcEventKey;
+
+    @Before
+    public void setUp() {
+        svcEventKey = new ServiceEventKey(new ServiceKey(TEST_NAMESPACE, TEST_SERVICE), EventType.INSTANCE);
+    }
+
+    /**
+     * 测试目的：验证资源已就绪时，向 addNotifier 传入 null 不会抛出 NPE。
+     * 测试场景：磁盘容灾命中且并发远程更新后，loadRemoteValue 会以 null 调用 addNotifier，
+     * 此时 checkResourceAvailable() 为 true，修复前会在 checkNotifyNow 中触发 NPE。
+     * 验证内容：addNotifier(null) 不抛异常，且不会将 null 加入监听列表。
+     */
+    @Test
+    public void testAddNotifierWithNullWhenResourceAvailableShouldNotThrow() throws Exception {
+        // Arrange：构造一个资源已就绪（已初始化且非来自文件）的 CacheObject
+        RegistryCacheValue cacheValue = mock(RegistryCacheValue.class);
+        lenient().when(cacheValue.isInitialized()).thenReturn(true);
+        lenient().when(cacheValue.isLoadedFromFile()).thenReturn(false);
+        CacheObject cacheObject = newCacheObject(cacheValue);
+
+        // Act & Assert：传入 null 不应抛出 NPE
+        assertThatCode(() -> cacheObject.addNotifier(null)).doesNotThrowAnyException();
+
+        // 监听列表应保持为空，null 不应被加入
+        List<EventCompleteNotifier> notifiers = getPrivateField(cacheObject, "notifiers");
+        assertThat(notifiers).isEmpty();
+    }
+
+    /**
+     * 测试目的：验证资源未就绪时，向 addNotifier 传入 null 同样不会抛异常。
+     * 测试场景：CacheObject 尚无任何缓存值。
+     * 验证内容：addNotifier(null) 不抛异常，监听列表为空。
+     */
+    @Test
+    public void testAddNotifierWithNullWhenResourceNotAvailableShouldNotThrow() throws Exception {
+        // Arrange：构造一个没有缓存值的 CacheObject
+        CacheObject cacheObject = newCacheObject(null);
+
+        // Act & Assert：传入 null 不应抛异常
+        assertThatCode(() -> cacheObject.addNotifier(null)).doesNotThrowAnyException();
+
+        List<EventCompleteNotifier> notifiers = getPrivateField(cacheObject, "notifiers");
+        assertThat(notifiers).isEmpty();
+    }
+
+    /**
+     * 测试目的：验证资源已就绪时，传入有效监听器会立即回调 complete 且不加入列表。
+     * 测试场景：缓存值已初始化且非来自文件。
+     * 验证内容：notifier.complete 被调用一次，监听列表为空（保持原有行为不变）。
+     */
+    @Test
+    public void testAddNotifierWithValueWhenResourceAvailableShouldCompleteNow() throws Exception {
+        // Arrange
+        RegistryCacheValue cacheValue = mock(RegistryCacheValue.class);
+        when(cacheValue.isInitialized()).thenReturn(true);
+        when(cacheValue.isLoadedFromFile()).thenReturn(false);
+        CacheObject cacheObject = newCacheObject(cacheValue);
+        EventCompleteNotifier notifier = mock(EventCompleteNotifier.class);
+
+        // Act
+        cacheObject.addNotifier(notifier);
+
+        // Assert：立即回调且不加入监听列表
+        verify(notifier).complete(svcEventKey);
+        List<EventCompleteNotifier> notifiers = getPrivateField(cacheObject, "notifiers");
+        assertThat(notifiers).isEmpty();
+    }
+
+    /**
+     * 测试目的：验证资源未就绪时，传入有效监听器会被加入监听列表且不立即回调。
+     * 测试场景：CacheObject 尚无缓存值。
+     * 验证内容：notifier 被加入列表，complete 未被调用（保持原有行为不变）。
+     */
+    @Test
+    public void testAddNotifierWithValueWhenResourceNotAvailableShouldAddToList() throws Exception {
+        // Arrange
+        CacheObject cacheObject = newCacheObject(null);
+        EventCompleteNotifier notifier = mock(EventCompleteNotifier.class);
+
+        // Act
+        cacheObject.addNotifier(notifier);
+
+        // Assert：加入监听列表，等待后续远程更新回调
+        verify(notifier, never()).complete(any());
+        List<EventCompleteNotifier> notifiers = getPrivateField(cacheObject, "notifiers");
+        assertThat(notifiers).containsExactly(notifier);
+    }
+
+    /**
+     * 构造一个 CacheObject，并通过反射设置其缓存值。
+     *
+     * @param cacheValue 缓存值，可为 null
+     * @return CacheObject 实例
+     */
+    private CacheObject newCacheObject(RegistryCacheValue cacheValue) throws Exception {
+        CacheObject cacheObject = new CacheObject(cacheHandler, svcEventKey, registry);
+        AtomicReference<RegistryCacheValue> valueRef = getPrivateField(cacheObject, "value");
+        valueRef.set(cacheValue);
+        return cacheObject;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getPrivateField(Object object, String fieldName) throws Exception {
+        Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(object);
+    }
+}

--- a/polaris-plugins/polaris-plugins-registry/registry-memory/src/test/java/com/tencent/polaris/plugins/registry/memory/InMemoryRegistryTest.java
+++ b/polaris-plugins/polaris-plugins-registry/registry-memory/src/test/java/com/tencent/polaris/plugins/registry/memory/InMemoryRegistryTest.java
@@ -1,0 +1,180 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.plugins.registry.memory;
+
+import com.google.protobuf.Message;
+import com.tencent.polaris.api.plugin.registry.CacheHandler;
+import com.tencent.polaris.api.plugin.registry.EventCompleteNotifier;
+import com.tencent.polaris.api.plugin.server.ServerConnector;
+import com.tencent.polaris.api.pojo.RegistryCacheValue;
+import com.tencent.polaris.api.pojo.ServiceEventKey;
+import com.tencent.polaris.api.pojo.ServiceEventKey.EventType;
+import com.tencent.polaris.api.pojo.ServiceKey;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link InMemoryRegistry}.
+ *
+ * @author hewei
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class InMemoryRegistryTest {
+
+    private static final String TEST_NAMESPACE = "TestNamespace";
+
+    private static final String TEST_SERVICE = "TestService";
+
+    @Mock
+    private ServerConnector connector;
+
+    @Mock
+    private MessagePersistHandler messagePersistHandler;
+
+    @Mock
+    private CacheHandler cacheHandler;
+
+    @InjectMocks
+    private InMemoryRegistry registry;
+
+    private ServiceEventKey svcEventKey;
+
+    @Before
+    public void setUp() {
+        svcEventKey = new ServiceEventKey(new ServiceKey(TEST_NAMESPACE, TEST_SERVICE), EventType.INSTANCE);
+    }
+
+    /**
+     * 测试目的：验证以 null 调用 loadRemoteValue 不会抛出 NPE。
+     * 测试场景：resourceMap 中已存在"远程已更新且资源就绪"的 CacheObject，
+     * 对应"磁盘容灾命中且已远程更新"分支中 loadRemoteValue(key, null) 的调用。
+     * 验证内容：loadRemoteValue(key, null) 不抛异常，且正常触发往 serverConnector 注册。
+     */
+    @Test
+    public void testLoadRemoteValueWithNullNotifierShouldNotThrow() throws Exception {
+        // Arrange：预置一个"远程已更新且资源就绪"的 CacheObject
+        setPrivateField(registry, "persistEnable", true);
+        Map<ServiceEventKey, CacheObject> resourceMap = getPrivateField(registry, "resourceMap");
+        resourceMap.put(svcEventKey, buildRemoteUpdatedCacheObject());
+
+        // Act & Assert：以 null 调用 loadRemoteValue 不应抛 NPE
+        assertThatCode(() -> invokeLoadRemoteValue(svcEventKey, null)).doesNotThrowAnyException();
+
+        // 应正常触发往 serverConnector 注册
+        verify(connector).registerServiceHandler(any());
+    }
+
+    /**
+     * 测试目的：复现"磁盘容灾命中且并发远程更新"竞态分支，验证不会抛 NPE。
+     * 测试场景：persistEnable=true 且磁盘容灾文件可读；在 loadFileCache 读取磁盘期间，
+     * 另一线程已把该资源远程更新并放入 resourceMap，使 isRemoteUpdated() 返回 true，
+     * 从而进入以 null 调用 loadRemoteValue 的分支。修复前会在 checkNotifyNow 中触发 NPE。
+     * 验证内容：loadResources 不抛 NPE，且原始 notifier 被正常回调 complete。
+     */
+    @Test
+    public void testLoadResourcesWithRemoteUpdatedFileCacheShouldNotThrowNPE() throws Exception {
+        // Arrange
+        setPrivateField(registry, "persistEnable", true);
+        Map<ServiceEventKey, CacheObject> resourceMap = getPrivateField(registry, "resourceMap");
+        CacheObject remoteUpdatedCache = buildRemoteUpdatedCacheObject();
+        Message message = mock(Message.class);
+        // 模拟竞态：读取磁盘文件时，另一线程已完成远程更新并将对象放入 resourceMap，
+        // 因此后续 addOrGetCacheObject 的 computeIfAbsent 会直接命中这个"远程已更新"的对象
+        when(messagePersistHandler.loadPersistedServices(any(), any())).thenAnswer(invocation -> {
+            resourceMap.put(svcEventKey, remoteUpdatedCache);
+            return message;
+        });
+        EventCompleteNotifier notifier = mock(EventCompleteNotifier.class);
+
+        // Act & Assert：走"磁盘容灾命中且已远程更新"分支，内部以 null 调用 loadRemoteValue，不应抛 NPE
+        assertThatCode(() -> invokeLoadResources(svcEventKey, notifier)).doesNotThrowAnyException();
+
+        // 原始 notifier 应被正常回调
+        verify(notifier).complete(svcEventKey);
+    }
+
+    /**
+     * 构造一个"远程已更新且资源就绪"的 CacheObject。
+     *
+     * @return CacheObject 实例
+     */
+    private CacheObject buildRemoteUpdatedCacheObject() throws Exception {
+        CacheObject cacheObject = new CacheObject(cacheHandler, svcEventKey, registry);
+        RegistryCacheValue cacheValue = mock(RegistryCacheValue.class);
+        lenient().when(cacheValue.isInitialized()).thenReturn(true);
+        lenient().when(cacheValue.isLoadedFromFile()).thenReturn(false);
+        AtomicReference<RegistryCacheValue> valueRef = getPrivateField(cacheObject, "value");
+        valueRef.set(cacheValue);
+        AtomicBoolean remoteUpdated = getPrivateField(cacheObject, "remoteUpdated");
+        remoteUpdated.set(true);
+        return cacheObject;
+    }
+
+    private void invokeLoadRemoteValue(ServiceEventKey key, EventCompleteNotifier notifier) throws Throwable {
+        Method method = InMemoryRegistry.class.getDeclaredMethod("loadRemoteValue",
+                ServiceEventKey.class, EventCompleteNotifier.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(registry, key, notifier);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    private void invokeLoadResources(ServiceEventKey key, EventCompleteNotifier notifier) throws Throwable {
+        Method method = InMemoryRegistry.class.getDeclaredMethod("loadResources",
+                ServiceEventKey.class, EventCompleteNotifier.class);
+        method.setAccessible(true);
+        try {
+            method.invoke(registry, key, notifier);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T getPrivateField(Object object, String fieldName) throws Exception {
+        Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (T) field.get(object);
+    }
+
+    private static void setPrivateField(Object object, String fieldName, Object value) throws Exception {
+        Field field = object.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(object, value);
+    }
+}


### PR DESCRIPTION
修复gateway集成sct使用WebClient调用远程接口时，使用负载均衡时发现InMemoryRegistry发生空指针异常，原因是InMemoryRegistry调用loadResources时对于notifier没有做空防护。

版本：
SCT: 2.1.2.0-2024.0.3