### PR TITLE
feat:sensitive data encryption

### DIFF
--- a/polaris-common/polaris-encrypt/src/main/java/com/tencent/polaris/encrypt/EncryptConfig.java
+++ b/polaris-common/polaris-encrypt/src/main/java/com/tencent/polaris/encrypt/EncryptConfig.java
@@ -17,7 +17,6 @@
 
 package com.tencent.polaris.encrypt;
 
-import com.tencent.polaris.api.utils.ClassUtils;
 import com.tencent.polaris.api.utils.StringUtils;
 
 public class EncryptConfig {
@@ -98,7 +97,7 @@ public class EncryptConfig {
      * @return true：需要解密；false：不需要解密
      */
     public static Boolean needDecrypt(Object content) {
-        if (null == content || !ClassUtils.isClassPresent("org.bouncycastle.jce.provider.BouncyCastleProvider")) {
+        if (null == content || !EncryptConstants.isBouncyCastlePresent()) {
             return false;
         } else {
             String stringValue = String.valueOf(content);

--- a/polaris-common/polaris-encrypt/src/main/java/com/tencent/polaris/encrypt/EncryptConstants.java
+++ b/polaris-common/polaris-encrypt/src/main/java/com/tencent/polaris/encrypt/EncryptConstants.java
@@ -1,0 +1,51 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.encrypt;
+
+import com.tencent.polaris.api.utils.ClassUtils;
+
+/**
+ * Shared encrypt constants that must stay loadable without BouncyCastle.
+ *
+ * <p>Do not put these on {@code AESUtil}: its static initializer instantiates
+ * {@code BouncyCastleProvider}, so a presence check against AESUtil would throw
+ * {@code NoClassDefFoundError} before the check runs.
+ *
+ * @author evelynwei
+ */
+public class EncryptConstants {
+
+    /**
+     * Symmetric algorithm name written into encryptAlgo and used by JCE AES APIs.
+     */
+    public static final String ALGO_AES = "AES";
+
+    /**
+     * BouncyCastle Provider class name for presence checks before loading AESUtil or RSAUtil.
+     */
+    public static final String BOUNCY_CASTLE_PROVIDER = "org.bouncycastle.jce.provider.BouncyCastleProvider";
+
+    /**
+     * Whether the optional BouncyCastle provider is on the classpath.
+     *
+     * @return true if the provider class can be loaded
+     */
+    public static boolean isBouncyCastlePresent() {
+        return ClassUtils.isClassPresent(BOUNCY_CASTLE_PROVIDER);
+    }
+}

--- a/polaris-common/polaris-encrypt/src/main/java/com/tencent/polaris/encrypt/util/AESUtil.java
+++ b/polaris-common/polaris-encrypt/src/main/java/com/tencent/polaris/encrypt/util/AESUtil.java
@@ -20,6 +20,7 @@ package com.tencent.polaris.encrypt.util;
 import com.tencent.polaris.api.exception.ErrorCode;
 import com.tencent.polaris.api.exception.PolarisException;
 import com.tencent.polaris.api.utils.StringUtils;
+import com.tencent.polaris.encrypt.EncryptConstants;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import javax.crypto.Cipher;
@@ -48,7 +49,7 @@ public class AESUtil {
     public static byte[] generateAesKey() {
         KeyGenerator keyGenerator;
         try {
-            keyGenerator = KeyGenerator.getInstance("AES");
+            keyGenerator = KeyGenerator.getInstance(EncryptConstants.ALGO_AES);
         } catch (NoSuchAlgorithmException e) {
             throw new PolarisException(ErrorCode.AES_KEY_GENERATE_ERROR, e.getMessage());
         }
@@ -66,7 +67,7 @@ public class AESUtil {
     public static byte[] generateAesKey(String seed) {
         KeyGenerator keyGenerator;
         try {
-            keyGenerator = KeyGenerator.getInstance("AES");
+            keyGenerator = KeyGenerator.getInstance(EncryptConstants.ALGO_AES);
             SecureRandom secureRandom = SecureRandom.getInstance("SHA1PRNG");
             secureRandom.setSeed(SHA256.encode(seed));
             keyGenerator.init(256, secureRandom);
@@ -88,7 +89,8 @@ public class AESUtil {
             Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding", "BC");
             byte[] iv = new byte[cipher.getBlockSize()];
             System.arraycopy(password, 0, iv, 0, cipher.getBlockSize());
-            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(password, "AES"), new IvParameterSpec(iv));
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(password, EncryptConstants.ALGO_AES),
+                    new IvParameterSpec(iv));
             byte[] bytes = cipher.doFinal(content.getBytes());
             return Base64.getEncoder().encodeToString(bytes);
         } catch (Exception e) {
@@ -110,7 +112,7 @@ public class AESUtil {
         try {
             byte[] enCodeFormat = generateAesKey(password);
             // 根据给定的字节数组构造一个密钥。enCodeFormat：密钥内容；"AES"：与给定的密钥内容相关联的密钥算法的名称
-            SecretKeySpec skSpec = new SecretKeySpec(enCodeFormat, "AES");
+            SecretKeySpec skSpec = new SecretKeySpec(enCodeFormat, EncryptConstants.ALGO_AES);
             // 创建一个实现指定转换的 Cipher对象，该转换由指定的提供程序提供。
             // "AES/ECB/PKCS7Padding"：转换的名称；"BC"：提供程序的名称
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS7Padding", "BC");
@@ -136,7 +138,8 @@ public class AESUtil {
             Cipher cipher = Cipher.getInstance("AES/CBC/PKCS7Padding", "BC");
             byte[] iv = new byte[cipher.getBlockSize()];
             System.arraycopy(password, 0, iv, 0, cipher.getBlockSize());
-            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(password, "AES"), new IvParameterSpec(iv));
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(password, EncryptConstants.ALGO_AES),
+                    new IvParameterSpec(iv));
             byte[] paddingPlaintext = cipher.doFinal(Base64.getDecoder().decode(content));
             return new String(paddingPlaintext);
         } catch (Exception e) {
@@ -158,7 +161,7 @@ public class AESUtil {
         try {
             byte[] enCodeFormat = generateAesKey(password);
             // 根据给定的字节数组构造一个密钥。enCodeFormat：密钥内容；"AES"：与给定的密钥内容相关联的密钥算法的名称
-            SecretKeySpec skSpec = new SecretKeySpec(enCodeFormat, "AES");
+            SecretKeySpec skSpec = new SecretKeySpec(enCodeFormat, EncryptConstants.ALGO_AES);
             // 创建一个实现指定转换的 Cipher对象，该转换由指定的提供程序提供。
             // "AES/ECB/PKCS7Padding"：转换的名称；"BC"：提供程序的名称
             Cipher cipher = Cipher.getInstance("AES/ECB/PKCS7Padding", "BC");

--- a/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/ConfigFile.java
+++ b/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/ConfigFile.java
@@ -78,4 +78,21 @@ public interface ConfigFile extends ConfigFileMetadata {
      */
     void removeChangeListener(ConfigFileChangeListener listener);
 
+    /**
+     * 该配置文件在服务端是否为加密配置。
+     *
+     * <p>供上层框架（如 Spring Cloud Tencent）在**首次加载**时就能判断敏感性：加密标记原本只出现在
+     * 变更事件携带的插件层对象上，首次加载拿不到，导致上层只能靠开关粗粒度兜底。
+     *
+     * <p>取值来自服务端下发的响应对象，是逐文件真值。注意加密过滤器会在**请求**前把该标记置为 true
+     * 用于声明客户端支持加密，因此只有响应侧对象的该字段可信。
+     *
+     * <p>default 实现返回 false：本接口有外部实现者，加密能力是可选特性，未覆写即视为非加密。
+     *
+     * @return 加密配置返回 true
+     */
+    default boolean isEncrypted() {
+        return false;
+    }
+
 }

--- a/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/ConfigFileChangeEvent.java
+++ b/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/ConfigFileChangeEvent.java
@@ -49,12 +49,16 @@ public class ConfigFileChangeEvent {
         return changeType;
     }
 
+    /**
+     * 不输出 oldValue 与 newValue：加密配置的正文不得进入日志文件。
+     * 需要取值的业务场景请使用 getOldValue 与 getNewValue。
+     *
+     * @return 仅含文件坐标与变更类型的字符串
+     */
     @Override
     public String toString() {
         return "ConfigFileChangeEvent{" +
                "configFileMetadata=" + configFileMetadata +
-               ", oldValue='" + oldValue + '\'' +
-               ", newValue='" + newValue + '\'' +
                ", changeType=" + changeType +
                '}';
     }

--- a/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/ConfigPropertyChangeInfo.java
+++ b/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/ConfigPropertyChangeInfo.java
@@ -52,12 +52,16 @@ public class ConfigPropertyChangeInfo {
         return changeType;
     }
 
+    /**
+     * 不输出 oldValue 与 newValue：加密配置的正文不得进入日志文件。
+     * 需要取值的业务场景请使用 getOldValue 与 getNewValue。
+     *
+     * @return 仅含属性名与变更类型的字符串
+     */
     @Override
     public String toString() {
         return "ConfigPropertyChangeInfo{" +
-               ", propertyName='" + propertyName + '\'' +
-               ", oldValue='" + oldValue + '\'' +
-               ", newValue='" + newValue + '\'' +
+               "propertyName='" + propertyName + '\'' +
                ", changeType=" + changeType +
                '}';
     }

--- a/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/EffectiveValue.java
+++ b/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/EffectiveValue.java
@@ -45,13 +45,43 @@ public class EffectiveValue {
      * 与 {@link #propertySource} 的区别：后者是给人看的来源标识（字符串），前者是给 SDK 判定用的
      * 结构化坐标，仅在客户端内部使用，不进入上报报文。
      * <p>
-     * 来源不是 polaris 配置文件（环境变量、本地配置文件等）或采集侧无法归因时为 null，
-     * 此时 SDK 退回保守策略。
+     * 仅当 {@link #sourceKind} 为 {@link SourceKind#POLARIS_FILE} 时有值。
      */
     private final ConfigFileMetadata sourceFile;
 
     /**
-     * 兼容旧采集侧的构造器，来源坐标视为未知。
+     * 生效值来源的归因结论。见 {@link SourceKind}。
+     */
+    private final SourceKind sourceKind;
+
+    /**
+     * 生效值来源的归因结论。SDK 据此决定是否要为「来源可能是加密配置」而省略生效值。
+     * <p>
+     * 三态而非「坐标是否为 null」两态：坐标缺失同时对应两种截然不同的情形 —— 来源确实不是
+     * polaris 配置文件（不可能是加密配置，安全），以及采集侧压根没做归因（未知，只能保守）。
+     * 两者混为一谈会让环境变量、命令行这类外部覆盖的生效值被无谓地省略。
+     */
+    public enum SourceKind {
+
+        /**
+         * 采集侧未给出归因（旧版本采集侧，或归因过程本身失败）。SDK 退回保守策略。
+         */
+        UNKNOWN,
+
+        /**
+         * 来源是 polaris 配置文件，坐标见 {@link EffectiveValue#getSourceFile()}。
+         */
+        POLARIS_FILE,
+
+        /**
+         * 来源不是 polaris 配置文件（环境变量、命令行、系统属性等）。这类值不由配置中心下发，
+         * 因此不可能是加密配置的明文，SDK 应照常回传。
+         */
+        EXTERNAL
+    }
+
+    /**
+     * 兼容旧采集侧的构造器，来源视为未归因。
      *
      * @param fileValue 文件内原始值
      * @param effectiveValue 运行时生效值
@@ -62,7 +92,9 @@ public class EffectiveValue {
     }
 
     /**
-     * 全量构造器。
+     * 按来源坐标归因的构造器。坐标非空即 {@link SourceKind#POLARIS_FILE}，为空则视为未归因 ——
+     * 想显式声明「来源不是 polaris 配置文件」请用
+     * {@link #EffectiveValue(String, String, String, ConfigFileMetadata, SourceKind)}。
      *
      * @param fileValue 文件内原始值
      * @param effectiveValue 运行时生效值
@@ -71,10 +103,33 @@ public class EffectiveValue {
      */
     public EffectiveValue(String fileValue, String effectiveValue, String propertySource,
             ConfigFileMetadata sourceFile) {
+        this(fileValue, effectiveValue, propertySource, sourceFile,
+                sourceFile == null ? SourceKind.UNKNOWN : SourceKind.POLARIS_FILE);
+    }
+
+    /**
+     * 全量构造器。
+     * <p>
+     * 声明为 {@link SourceKind#POLARIS_FILE} 却未给坐标时降级为 {@link SourceKind#UNKNOWN}：
+     * 缺了坐标 SDK 无从反查加密态，此时保守处理而非放行。
+     *
+     * @param fileValue 文件内原始值
+     * @param effectiveValue 运行时生效值
+     * @param propertySource 生效值来源标识
+     * @param sourceFile 生效值来源的配置文件坐标，非 polaris 来源或无法归因时为 null
+     * @param sourceKind 来源归因结论，null 视为 {@link SourceKind#UNKNOWN}
+     */
+    public EffectiveValue(String fileValue, String effectiveValue, String propertySource,
+            ConfigFileMetadata sourceFile, SourceKind sourceKind) {
         this.fileValue = fileValue;
         this.effectiveValue = effectiveValue;
         this.propertySource = propertySource;
         this.sourceFile = sourceFile;
+        if (sourceKind == null || (sourceKind == SourceKind.POLARIS_FILE && sourceFile == null)) {
+            this.sourceKind = SourceKind.UNKNOWN;
+        } else {
+            this.sourceKind = sourceKind;
+        }
     }
 
     public String getFileValue() {
@@ -91,5 +146,9 @@ public class EffectiveValue {
 
     public ConfigFileMetadata getSourceFile() {
         return sourceFile;
+    }
+
+    public SourceKind getSourceKind() {
+        return sourceKind;
     }
 }

--- a/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/EffectiveValue.java
+++ b/polaris-configuration/polaris-configuration-api/src/main/java/com/tencent/polaris/configuration/api/core/EffectiveValue.java
@@ -39,10 +39,42 @@ public class EffectiveValue {
      */
     private final String propertySource;
 
+    /**
+     * 生效值实际来源的配置文件坐标，供 SDK 反查该来源文件是否为加密配置。
+     * <p>
+     * 与 {@link #propertySource} 的区别：后者是给人看的来源标识（字符串），前者是给 SDK 判定用的
+     * 结构化坐标，仅在客户端内部使用，不进入上报报文。
+     * <p>
+     * 来源不是 polaris 配置文件（环境变量、本地配置文件等）或采集侧无法归因时为 null，
+     * 此时 SDK 退回保守策略。
+     */
+    private final ConfigFileMetadata sourceFile;
+
+    /**
+     * 兼容旧采集侧的构造器，来源坐标视为未知。
+     *
+     * @param fileValue 文件内原始值
+     * @param effectiveValue 运行时生效值
+     * @param propertySource 生效值来源标识
+     */
     public EffectiveValue(String fileValue, String effectiveValue, String propertySource) {
+        this(fileValue, effectiveValue, propertySource, null);
+    }
+
+    /**
+     * 全量构造器。
+     *
+     * @param fileValue 文件内原始值
+     * @param effectiveValue 运行时生效值
+     * @param propertySource 生效值来源标识
+     * @param sourceFile 生效值来源的配置文件坐标，无法归因时为 null
+     */
+    public EffectiveValue(String fileValue, String effectiveValue, String propertySource,
+            ConfigFileMetadata sourceFile) {
         this.fileValue = fileValue;
         this.effectiveValue = effectiveValue;
         this.propertySource = propertySource;
+        this.sourceFile = sourceFile;
     }
 
     public String getFileValue() {
@@ -55,5 +87,9 @@ public class EffectiveValue {
 
     public String getPropertySource() {
         return propertySource;
+    }
+
+    public ConfigFileMetadata getSourceFile() {
+        return sourceFile;
     }
 }

--- a/polaris-configuration/polaris-configuration-api/src/test/java/com/tencent/polaris/configuration/api/core/ConfigFileChangeEventTest.java
+++ b/polaris-configuration/polaris-configuration-api/src/test/java/com/tencent/polaris/configuration/api/core/ConfigFileChangeEventTest.java
@@ -1,0 +1,122 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.configuration.api.core;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link ConfigFileChangeEvent}.
+ *
+ * @author evelynwei
+ */
+public class ConfigFileChangeEventTest {
+
+    private static final String OLD_CONTENT = "jdbc.password=old-secret-value";
+
+    private static final String NEW_CONTENT = "jdbc.password=new-secret-value";
+
+    /**
+     * 测试目的：验证变更事件的 toString 不再泄露变更前后的配置正文。
+     * 测试场景：事件持有加密配置解密后的旧值与新值。
+     * 验证内容：输出不含两者的值。
+     */
+    @Test
+    public void testToStringWithoutValues() {
+        // Arrange
+        ConfigFileChangeEvent event = assembleChangeEvent();
+
+        // Act
+        String str = event.toString();
+
+        // Assert
+        assertThat(str).doesNotContain(OLD_CONTENT);
+        assertThat(str).doesNotContain(NEW_CONTENT);
+    }
+
+    /**
+     * 测试目的：验证问题定位能力不退化。
+     * 测试场景：事件持有完整的文件坐标与变更类型。
+     * 验证内容：输出包含文件坐标与变更类型。
+     */
+    @Test
+    public void testToStringKeepsMetadata() {
+        // Arrange
+        ConfigFileChangeEvent event = assembleChangeEvent();
+
+        // Act
+        String str = event.toString();
+
+        // Assert
+        assertThat(str).contains("biz-config");
+        assertThat(str).contains("MODIFIED");
+    }
+
+    /**
+     * 测试目的：验证取值 API 不受 toString 收敛影响。
+     * 测试场景：业务通过 getter 读取变更前后的值。
+     * 验证内容：getter 仍返回原值。
+     */
+    @Test
+    public void testGettersKeepValues() {
+        // Arrange
+        ConfigFileChangeEvent event = assembleChangeEvent();
+
+        // Act & Assert
+        assertThat(event.getOldValue()).isEqualTo(OLD_CONTENT);
+        assertThat(event.getNewValue()).isEqualTo(NEW_CONTENT);
+        assertThat(event.getChangeType()).isEqualTo(ChangeType.MODIFIED);
+    }
+
+    private ConfigFileChangeEvent assembleChangeEvent() {
+        return new ConfigFileChangeEvent(new TestConfigFileMetadata(), OLD_CONTENT, NEW_CONTENT,
+                ChangeType.MODIFIED);
+    }
+
+    /**
+     * 测试用配置文件坐标，toString 输出三元组，用于验证事件仍保留可定位信息。
+     */
+    private static class TestConfigFileMetadata implements ConfigFileMetadata {
+
+        @Override
+        public String getNamespace() {
+            return "default";
+        }
+
+        @Override
+        public String getFileGroup() {
+            return "biz-group";
+        }
+
+        @Override
+        public String getFileName() {
+            return "biz-config";
+        }
+
+        @Override
+        public String getFileVersion() {
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return "ConfigFileMetadata{namespace='default', fileGroup='biz-group', fileName='biz-config'}";
+        }
+    }
+}

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
@@ -310,13 +310,12 @@ public class ClientEventQueryHandler {
     }
 
     /**
-     * 明文 ACK 前的脱敏。conflicts 与 effectiveValue 由 {@link ConfigEffectiveValueProvider} 跨全部
-     * 被监听文件采集，其中可能包含加密文件的值；本文件未加密时无密钥可用，只能去掉这些值，
-     * 仅保留「此处存在冲突」这一事实与来源坐标 —— 服务端定位冲突并不需要值本身。
+     * 明文 ACK 前的脱敏。effectiveValue 由 {@link ConfigEffectiveValueProvider} 跨全部被监听文件
+     * 采集，其中可能包含加密文件的值；本文件未加密时无密钥可用，加密来源的生效值必须去掉。
+     * 冲突项 {@code conflicts[].value} 是冲突文件里该 key 的 file_value，控制台要原样展示，不清空。
      *
-     * <p>两个维度都按「来源文件坐标」判定加密态：conflicts 自带坐标；effectiveValue 的坐标由采集侧
-     * 经 {@link EffectiveValue#getSourceFile()} 给出。坐标缺失时退回保守策略，见
-     * {@link #shouldStripEffectiveValue}。
+     * <p>effectiveValue 的来源坐标由采集侧经 {@link EffectiveValue#getSourceFile()} 给出。
+     * 坐标缺失时退回保守策略，见 {@link #shouldStripEffectiveValue}。
      *
      * @param resolvedEntries 待回传的属性明细及其生效值来源坐标
      * @return ACK 明细列表，元素已就地脱敏
@@ -326,7 +325,6 @@ public class ClientEventQueryHandler {
         List<ClientEventAck.PropertyEntry> entries = new ArrayList<>(resolvedEntries.size());
         for (ResolvedEntry resolved : resolvedEntries) {
             ClientEventAck.PropertyEntry entry = resolved.getEntry();
-            stripEncryptedConflictValues(entry);
             if (shouldStripEffectiveValue(resolved, encryptedSourcePossible)) {
                 entry.setEffectiveValue(null);
             }
@@ -377,25 +375,6 @@ public class ClientEventQueryHandler {
             entries.add(resolved.getEntry());
         }
         return entries;
-    }
-
-    private void stripEncryptedConflictValues(ClientEventAck.PropertyEntry entry) {
-        List<ClientEventAck.ConflictEntry> conflicts = entry.getConflicts();
-        if (conflicts != null) {
-            for (ClientEventAck.ConflictEntry conflict : conflicts) {
-                if (conflict != null && isEncryptedWatchedFile(conflict)) {
-                    conflict.setValue(null);
-                }
-            }
-        }
-    }
-
-    /**
-     * 判断冲突来源文件是否为加密配置。
-     */
-    private boolean isEncryptedWatchedFile(ClientEventAck.ConflictEntry conflict) {
-        return isEncryptedWatchedFile(new DefaultConfigFileMetadata(emptyIfNull(conflict.getNamespace()),
-                emptyIfNull(conflict.getGroup()), emptyIfNull(conflict.getFileName())));
     }
 
     /**

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
@@ -19,12 +19,12 @@ package com.tencent.polaris.configuration.client.internal;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.tencent.polaris.api.utils.ClassUtils;
 import com.tencent.polaris.configuration.api.core.ConfigEffectiveValueProvider;
 import com.tencent.polaris.configuration.api.core.ConfigEffectiveValueRegistration;
 import com.tencent.polaris.configuration.api.core.ConfigFileMetadata;
 import com.tencent.polaris.configuration.api.core.ConfigKeyConflict;
 import com.tencent.polaris.configuration.api.core.EffectiveValue;
+import com.tencent.polaris.encrypt.EncryptConstants;
 import com.tencent.polaris.encrypt.util.AESUtil;
 import com.tencent.polaris.encrypt.util.RSAUtil;
 import com.tencent.polaris.logging.LoggerFactory;
@@ -74,11 +74,6 @@ public class ClientEventQueryHandler {
 
     /** 已监听该配置文件但尚未拉取生效（首次拉取失败/重试中）。 */
     private static final String REASON_PENDING = "pending";
-
-    /**
-     * BouncyCastle Provider 全限定名，用于在触碰 AESUtil / RSAUtil 之前预判其是否在位。
-     */
-    private static final String BOUNCY_CASTLE_PROVIDER = "org.bouncycastle.jce.provider.BouncyCastleProvider";
 
     /**
      * 序列化 ACK 自身失败时的兜底应答，避免服务端收到无法诊断的空对象。
@@ -230,7 +225,7 @@ public class ClientEventQueryHandler {
      */
     private boolean isAckCryptoAvailable(ConfigFileSnapshot snapshot) {
         return snapshot.getEncryptAlgo() != null && !snapshot.getEncryptAlgo().isEmpty()
-                && ClassUtils.isClassPresent(BOUNCY_CASTLE_PROVIDER);
+                && EncryptConstants.isBouncyCastlePresent();
     }
 
     /**

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
@@ -19,6 +19,7 @@ package com.tencent.polaris.configuration.client.internal;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.tencent.polaris.api.utils.ClassUtils;
 import com.tencent.polaris.configuration.api.core.ConfigEffectiveValueProvider;
 import com.tencent.polaris.configuration.api.core.ConfigEffectiveValueRegistration;
 import com.tencent.polaris.configuration.api.core.ConfigFileMetadata;
@@ -73,6 +74,11 @@ public class ClientEventQueryHandler {
 
     /** 已监听该配置文件但尚未拉取生效（首次拉取失败/重试中）。 */
     private static final String REASON_PENDING = "pending";
+
+    /**
+     * BouncyCastle Provider 全限定名，用于在触碰 AESUtil / RSAUtil 之前预判其是否在位。
+     */
+    private static final String BOUNCY_CASTLE_PROVIDER = "org.bouncycastle.jce.provider.BouncyCastleProvider";
 
     /**
      * 序列化 ACK 自身失败时的兜底应答，避免服务端收到无法诊断的空对象。
@@ -201,7 +207,7 @@ public class ClientEventQueryHandler {
             if (snapshot.getEncryptAlgo() != null && !snapshot.getEncryptAlgo().isEmpty()) {
                 ack.setEncryptAlgo(snapshot.getEncryptAlgo());
             }
-            String wrappedDataKey = wrapAckDataKey(snapshot.getDataKey(), publicKey);
+            String wrappedDataKey = wrapAckDataKey(snapshot, publicKey);
             if (!wrappedDataKey.isEmpty()) {
                 ack.setDataKey(wrappedDataKey);
             }
@@ -209,21 +215,42 @@ public class ClientEventQueryHandler {
     }
 
     /**
+     * ACK 侧能否用快照里的 data_key 做加密，两个前提缺一不可。
+     *
+     * <p>一是密钥已被加密过滤器解包成明文 AES 密钥。判据取 encryptAlgo：它只由
+     * {@code CryptoConfigFileFilter} 在解包成功时与明文密钥一起写入，连接器只写 encrypted 和
+     * 服务端下发的包裹密钥。过滤器未启用时 dataKey 仍是 RSA 包裹态，再包一层发回去服务端解不开。
+     *
+     * <p>二是 BouncyCastle 在位。AESUtil 与 RSAUtil 的静态初始化依赖它，缺失时抛的是
+     * NoClassDefFoundError 而非 RuntimeException，不预判就会让整个 ACK 变成 internal_error；
+     * 而配置是否加密由服务端决定，与客户端有没有装 BouncyCastle 无关，这条路径确实可达。
+     *
+     * @param snapshot 配置快照
+     * @return 可以使用返回 true
+     */
+    private boolean isAckCryptoAvailable(ConfigFileSnapshot snapshot) {
+        return snapshot.getEncryptAlgo() != null && !snapshot.getEncryptAlgo().isEmpty()
+                && ClassUtils.isClassPresent(BOUNCY_CASTLE_PROVIDER);
+    }
+
+    /**
      * Wrap the symmetric data key with the query RSA public key.
      * Missing key or encrypt failure returns empty so Gson omits data_key; never return plaintext.
      *
-     * @param plainDataKey Base64 plaintext AES key from snapshot
+     * @param snapshot 配置快照，data_key 为 Base64 明文 AES 密钥
      * @param publicKey PKCS1 / X.509 / PEM public key from PUSH
      * @return RSA wrapped data key, or empty on failure
      */
-    private String wrapAckDataKey(String plainDataKey, String publicKey) {
+    private String wrapAckDataKey(ConfigFileSnapshot snapshot, String publicKey) {
         String wrapped = "";
-        if (plainDataKey != null && !plainDataKey.isEmpty() && publicKey != null && !publicKey.isEmpty()) {
+        String plainDataKey = snapshot.getDataKey();
+        if (plainDataKey != null && !plainDataKey.isEmpty() && publicKey != null && !publicKey.isEmpty()
+                && isAckCryptoAvailable(snapshot)) {
             try {
                 byte[] rawKey = Base64.getDecoder().decode(plainDataKey);
                 wrapped = RSAUtil.encryptToBase64(rawKey, publicKey);
-            } catch (RuntimeException e) {
-                LOG.warn("[Config] rsa wrap data_key failed: {}", e.getMessage());
+            } catch (Throwable t) {
+                LOG.warn("[Config] rsa wrap data_key failed: {}", t.getMessage());
                 wrapped = "";
             }
         }
@@ -272,13 +299,13 @@ public class ClientEventQueryHandler {
         }
     }
 
-    private void applyProperties(ClientEventAck ack, List<ClientEventAck.PropertyEntry> entries,
+    private void applyProperties(ClientEventAck ack, List<ResolvedEntry> resolvedEntries,
             ConfigFileSnapshot snapshot) {
-        if (!entries.isEmpty() && snapshot.isEncrypted()) {
-            setEncryptedProperties(ack, entries, snapshot);
-        } else if (!entries.isEmpty()) {
+        if (!resolvedEntries.isEmpty() && snapshot.isEncrypted()) {
+            setEncryptedProperties(ack, toPropertyEntries(resolvedEntries), snapshot);
+        } else if (!resolvedEntries.isEmpty()) {
             // 明文 ACK：entries 是跨文件采集的，来自加密文件的值不得以明文回传或进入日志
-            ack.setProperties(stripEncryptedSourceValues(entries));
+            ack.setProperties(stripEncryptedSourceValues(resolvedEntries));
         }
     }
 
@@ -287,43 +314,94 @@ public class ClientEventQueryHandler {
      * 被监听文件采集，其中可能包含加密文件的值；本文件未加密时无密钥可用，只能去掉这些值，
      * 仅保留「此处存在冲突」这一事实与来源坐标 —— 服务端定位冲突并不需要值本身。
      *
-     * <p>局限：effectiveValue 的来源以 Spring property source 名标识，无法反查文件坐标，
-     * 因此只能在存在加密来源冲突项时一并去掉。彻底修复需采集侧（SCT provider）标记来源加密状态。
+     * <p>两个维度都按「来源文件坐标」判定加密态：conflicts 自带坐标；effectiveValue 的坐标由采集侧
+     * 经 {@link EffectiveValue#getSourceFile()} 给出。坐标缺失时退回保守策略，见
+     * {@link #shouldStripEffectiveValue}。
      *
-     * @param entries 待回传的属性明细
-     * @return 原列表，元素已就地脱敏
+     * @param resolvedEntries 待回传的属性明细及其生效值来源坐标
+     * @return ACK 明细列表，元素已就地脱敏
      */
-    private List<ClientEventAck.PropertyEntry> stripEncryptedSourceValues(
-            List<ClientEventAck.PropertyEntry> entries) {
-        for (ClientEventAck.PropertyEntry entry : entries) {
-            if (stripEncryptedConflictValues(entry)) {
+    private List<ClientEventAck.PropertyEntry> stripEncryptedSourceValues(List<ResolvedEntry> resolvedEntries) {
+        boolean encryptedSourcePossible = watchRegistry != null && watchRegistry.hasEncryptedWatchedFile();
+        List<ClientEventAck.PropertyEntry> entries = new ArrayList<>(resolvedEntries.size());
+        for (ResolvedEntry resolved : resolvedEntries) {
+            ClientEventAck.PropertyEntry entry = resolved.getEntry();
+            stripEncryptedConflictValues(entry);
+            if (shouldStripEffectiveValue(resolved, encryptedSourcePossible)) {
                 entry.setEffectiveValue(null);
             }
+            entries.add(entry);
         }
         return entries;
     }
 
-    private boolean stripEncryptedConflictValues(ClientEventAck.PropertyEntry entry) {
-        boolean stripped = false;
+    /**
+     * 是否必须去掉生效值。
+     *
+     * <p>采集侧给出了来源坐标时按坐标精确判定：仅当该来源文件确为加密配置才去掉，明文来源照常回传，
+     * 配置生效查询不受影响。
+     *
+     * <p>坐标缺失（旧版本采集侧，或来源不是 polaris 配置文件）时无法归因，退回 fail-closed：
+     * 只要存在加密态被监听文件，且生效值与本文件 fileValue 不一致（说明该值来自别处），就去掉。
+     * 生效值等于 fileValue 时即本文件自身的明文，保留不泄露。
+     *
+     * @param resolved 属性明细及其来源坐标
+     * @param encryptedSourcePossible 是否存在加密态被监听文件
+     * @return 需要去掉生效值返回 true
+     */
+    private boolean shouldStripEffectiveValue(ResolvedEntry resolved, boolean encryptedSourcePossible) {
+        boolean strip;
+        ConfigFileMetadata sourceFile = resolved.getSourceFile();
+        if (sourceFile != null) {
+            strip = isEncryptedWatchedFile(sourceFile);
+        } else {
+            strip = encryptedSourcePossible && isOverriddenByOtherSource(resolved.getEntry());
+        }
+        return strip;
+    }
+
+    /**
+     * 生效值是否来自本文件之外的来源。fileValue 为 null 时任何非空生效值都来自别处。
+     */
+    private boolean isOverriddenByOtherSource(ClientEventAck.PropertyEntry entry) {
+        String effectiveValue = entry.getEffectiveValue();
+        return effectiveValue != null && !effectiveValue.equals(entry.getFileValue());
+    }
+
+    private List<ClientEventAck.PropertyEntry> toPropertyEntries(List<ResolvedEntry> resolvedEntries) {
+        List<ClientEventAck.PropertyEntry> entries = new ArrayList<>(resolvedEntries.size());
+        for (ResolvedEntry resolved : resolvedEntries) {
+            entries.add(resolved.getEntry());
+        }
+        return entries;
+    }
+
+    private void stripEncryptedConflictValues(ClientEventAck.PropertyEntry entry) {
         List<ClientEventAck.ConflictEntry> conflicts = entry.getConflicts();
         if (conflicts != null) {
             for (ClientEventAck.ConflictEntry conflict : conflicts) {
                 if (conflict != null && isEncryptedWatchedFile(conflict)) {
                     conflict.setValue(null);
-                    stripped = true;
                 }
             }
         }
-        return stripped;
     }
 
     /**
-     * 判断冲突来源文件是否为加密配置。加密状态取自本地已监听文件的快照，不依赖采集侧上报。
+     * 判断冲突来源文件是否为加密配置。
      */
     private boolean isEncryptedWatchedFile(ClientEventAck.ConflictEntry conflict) {
-        ConfigFileMetadata metadata = new DefaultConfigFileMetadata(emptyIfNull(conflict.getNamespace()),
-                emptyIfNull(conflict.getGroup()), emptyIfNull(conflict.getFileName()));
-        RemoteConfigFileRepo repo = watchRegistry == null ? null : watchRegistry.getWatchedFile(metadata);
+        return isEncryptedWatchedFile(new DefaultConfigFileMetadata(emptyIfNull(conflict.getNamespace()),
+                emptyIfNull(conflict.getGroup()), emptyIfNull(conflict.getFileName())));
+    }
+
+    /**
+     * 判断给定坐标的文件是否为加密配置。加密状态取自本地已监听文件的快照，不依赖采集侧上报。
+     */
+    private boolean isEncryptedWatchedFile(ConfigFileMetadata metadata) {
+        ConfigFileMetadata key = new DefaultConfigFileMetadata(emptyIfNull(metadata.getNamespace()),
+                emptyIfNull(metadata.getFileGroup()), emptyIfNull(metadata.getFileName()));
+        RemoteConfigFileRepo repo = watchRegistry == null ? null : watchRegistry.getWatchedFile(key);
         ConfigFileSnapshot snapshot = repo == null ? null : repo.getSnapshot();
         return snapshot != null && snapshot.isEncrypted();
     }
@@ -332,24 +410,24 @@ public class ClientEventQueryHandler {
         return value == null ? "" : value;
     }
 
-    private List<ClientEventAck.PropertyEntry> buildPropertyEntries(ConfigEffectiveValueProvider provider,
+    private List<ResolvedEntry> buildPropertyEntries(ConfigEffectiveValueProvider provider,
             List<String> keys, ConfigFileMetadata metadata) {
-        List<ClientEventAck.PropertyEntry> entries = new ArrayList<>();
+        List<ResolvedEntry> entries = new ArrayList<>();
         List<String> omittedKeys = new ArrayList<>();
         int serializedBytes = 2;
         for (String key : keys) {
             if (key != null) {
-                ClientEventAck.PropertyEntry entry = buildPropertyEntry(provider, key, metadata);
-                boolean conflicted = hasConflict(entry);
+                ResolvedEntry resolved = buildPropertyEntry(provider, key, metadata);
+                boolean conflicted = hasConflict(resolved.getEntry());
                 if (conflicted) {
-                    int entryBytes = gson.toJson(entry).getBytes(StandardCharsets.UTF_8).length;
+                    int entryBytes = gson.toJson(resolved.getEntry()).getBytes(StandardCharsets.UTF_8).length;
                     int separatorBytes = entries.isEmpty() ? 0 : 1;
                     if (serializedBytes + separatorBytes + entryBytes > MAX_ACK_PROPERTIES_BYTES) {
                         LOG.warn("[Config] ack properties truncated, file = {}, included = {}, total = {}, limit = {} bytes",
                                 metadata, entries.size(), keys.size(), MAX_ACK_PROPERTIES_BYTES);
                         break;
                     }
-                    entries.add(entry);
+                    entries.add(resolved);
                     serializedBytes += separatorBytes + entryBytes;
                 } else {
                     omittedKeys.add(key);
@@ -362,14 +440,17 @@ public class ClientEventQueryHandler {
 
     private void setEncryptedProperties(ClientEventAck ack, List<ClientEventAck.PropertyEntry> entries,
             ConfigFileSnapshot snapshot) {
+        if (!isAckCryptoAvailable(snapshot)) {
+            return;
+        }
         byte[] aesKey = decodeAckAesKey(snapshot.getDataKey());
         if (aesKey == null) {
             return;
         }
         try {
             ack.setProperties(AESUtil.encrypt(gson.toJson(entries), aesKey));
-        } catch (RuntimeException e) {
-            LOG.warn("[Config] encrypt properties failed: {}", e.getMessage());
+        } catch (Throwable t) {
+            LOG.warn("[Config] encrypt properties failed: {}", t.getMessage());
         }
     }
 
@@ -395,12 +476,12 @@ public class ClientEventQueryHandler {
         }
     }
 
-    private void logPropertySelection(ConfigFileMetadata metadata, List<ClientEventAck.PropertyEntry> entries,
+    private void logPropertySelection(ConfigFileMetadata metadata, List<ResolvedEntry> entries,
             List<String> omittedKeys) {
         if (LOG.isDebugEnabled()) {
             List<String> conflictedKeys = new ArrayList<>(entries.size());
-            for (ClientEventAck.PropertyEntry entry : entries) {
-                conflictedKeys.add(entry.getKey());
+            for (ResolvedEntry resolved : entries) {
+                conflictedKeys.add(resolved.getEntry().getKey());
             }
             LOG.debug("[Config] ack properties, file = {}, conflicted = {}, omitted = {}",
                     metadata, conflictedKeys, omittedKeys);
@@ -424,17 +505,20 @@ public class ClientEventQueryHandler {
         return conflicted;
     }
 
-    private ClientEventAck.PropertyEntry buildPropertyEntry(ConfigEffectiveValueProvider provider, String key,
+    private ResolvedEntry buildPropertyEntry(ConfigEffectiveValueProvider provider, String key,
             ConfigFileMetadata metadata) {
         ClientEventAck.PropertyEntry entry = new ClientEventAck.PropertyEntry();
         entry.setKey(key);
-        fillEffectiveValue(provider, key, metadata, entry);
+        ConfigFileMetadata sourceFile = fillEffectiveValue(provider, key, metadata, entry);
         entry.setConflicts(buildConflicts(provider, key, metadata));
-        return entry;
+        return new ResolvedEntry(entry, sourceFile);
     }
 
-    private void fillEffectiveValue(ConfigEffectiveValueProvider provider, String key, ConfigFileMetadata metadata,
-            ClientEventAck.PropertyEntry entry) {
+    /**
+     * 填充生效值三字段，并返回生效值来源的文件坐标（采集侧未给出时为 null）。
+     */
+    private ConfigFileMetadata fillEffectiveValue(ConfigEffectiveValueProvider provider, String key,
+            ConfigFileMetadata metadata, ClientEventAck.PropertyEntry entry) {
         EffectiveValue effectiveValue;
         try {
             effectiveValue = provider.resolve(key, metadata);
@@ -442,11 +526,14 @@ public class ClientEventQueryHandler {
             LOG.warn("[Config] resolve effective value failed, key = {}", key);
             effectiveValue = null;
         }
+        ConfigFileMetadata sourceFile = null;
         if (effectiveValue != null) {
             entry.setPropertySource(effectiveValue.getPropertySource());
             entry.setFileValue(effectiveValue.getFileValue());
             entry.setEffectiveValue(effectiveValue.getEffectiveValue());
+            sourceFile = effectiveValue.getSourceFile();
         }
+        return sourceFile;
     }
 
     private List<ClientEventAck.ConflictEntry> buildConflicts(ConfigEffectiveValueProvider provider, String key,
@@ -506,6 +593,33 @@ public class ClientEventQueryHandler {
         } catch (RuntimeException e) {
             LOG.warn("[Config] marshal ack content failed: {}", e.getMessage());
             return MARSHAL_FAILED_ACK;
+        }
+    }
+
+    /**
+     * 采集结果的内部载体：ACK 明细 + 生效值来源的文件坐标。
+     *
+     * <p>坐标只用于客户端内部判定来源文件是否加密，**不放在**
+     * {@link ClientEventAck.PropertyEntry} 上，以免随 ACK 序列化外泄，或让上报报文多出一个
+     * 隐式协议字段。
+     */
+    private static final class ResolvedEntry {
+
+        private final ClientEventAck.PropertyEntry entry;
+
+        private final ConfigFileMetadata sourceFile;
+
+        ResolvedEntry(ClientEventAck.PropertyEntry entry, ConfigFileMetadata sourceFile) {
+            this.entry = entry;
+            this.sourceFile = sourceFile;
+        }
+
+        ClientEventAck.PropertyEntry getEntry() {
+            return entry;
+        }
+
+        ConfigFileMetadata getSourceFile() {
+            return sourceFile;
         }
     }
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
@@ -336,24 +336,27 @@ public class ClientEventQueryHandler {
     }
 
     /**
-     * 是否必须去掉生效值。
+     * 是否必须去掉生效值。按采集侧的来源归因分三种处置：
      *
-     * <p>采集侧给出了来源坐标时按坐标精确判定：仅当该来源文件确为加密配置才去掉，明文来源照常回传，
-     * 配置生效查询不受影响。
+     * <ul>
+     * <li>来源是 polaris 配置文件：按坐标精确判定，仅该文件确为加密配置才去掉，明文来源照常回传。</li>
+     * <li>来源不是 polaris 配置文件（环境变量、命令行、系统属性等）：该值不由配置中心下发，
+     * 不可能是加密配置的明文，照常回传。</li>
+     * <li>未归因（旧版本采集侧）：无从判断，退回 fail-closed —— 只要存在加密态被监听文件，
+     * 且生效值与本文件 fileValue 不一致（说明该值来自别处），就去掉。生效值等于 fileValue 时
+     * 即本文件自身的明文，保留不泄露。</li>
+     * </ul>
      *
-     * <p>坐标缺失（旧版本采集侧，或来源不是 polaris 配置文件）时无法归因，退回 fail-closed：
-     * 只要存在加密态被监听文件，且生效值与本文件 fileValue 不一致（说明该值来自别处），就去掉。
-     * 生效值等于 fileValue 时即本文件自身的明文，保留不泄露。
-     *
-     * @param resolved 属性明细及其来源坐标
+     * @param resolved 属性明细及其来源归因
      * @param encryptedSourcePossible 是否存在加密态被监听文件
      * @return 需要去掉生效值返回 true
      */
     private boolean shouldStripEffectiveValue(ResolvedEntry resolved, boolean encryptedSourcePossible) {
         boolean strip;
-        ConfigFileMetadata sourceFile = resolved.getSourceFile();
-        if (sourceFile != null) {
-            strip = isEncryptedWatchedFile(sourceFile);
+        if (resolved.getSourceKind() == EffectiveValue.SourceKind.POLARIS_FILE) {
+            strip = isEncryptedWatchedFile(resolved.getSourceFile());
+        } else if (resolved.getSourceKind() == EffectiveValue.SourceKind.EXTERNAL) {
+            strip = false;
         } else {
             strip = encryptedSourcePossible && isOverriddenByOtherSource(resolved.getEntry());
         }
@@ -509,15 +512,15 @@ public class ClientEventQueryHandler {
             ConfigFileMetadata metadata) {
         ClientEventAck.PropertyEntry entry = new ClientEventAck.PropertyEntry();
         entry.setKey(key);
-        ConfigFileMetadata sourceFile = fillEffectiveValue(provider, key, metadata, entry);
+        EffectiveValue resolved = fillEffectiveValue(provider, key, metadata, entry);
         entry.setConflicts(buildConflicts(provider, key, metadata));
-        return new ResolvedEntry(entry, sourceFile);
+        return new ResolvedEntry(entry, resolved);
     }
 
     /**
-     * 填充生效值三字段，并返回生效值来源的文件坐标（采集侧未给出时为 null）。
+     * 填充生效值三字段，并返回采集侧结果（含来源归因），采集失败时为 null。
      */
-    private ConfigFileMetadata fillEffectiveValue(ConfigEffectiveValueProvider provider, String key,
+    private EffectiveValue fillEffectiveValue(ConfigEffectiveValueProvider provider, String key,
             ConfigFileMetadata metadata, ClientEventAck.PropertyEntry entry) {
         EffectiveValue effectiveValue;
         try {
@@ -526,14 +529,12 @@ public class ClientEventQueryHandler {
             LOG.warn("[Config] resolve effective value failed, key = {}", key);
             effectiveValue = null;
         }
-        ConfigFileMetadata sourceFile = null;
         if (effectiveValue != null) {
             entry.setPropertySource(effectiveValue.getPropertySource());
             entry.setFileValue(effectiveValue.getFileValue());
             entry.setEffectiveValue(effectiveValue.getEffectiveValue());
-            sourceFile = effectiveValue.getSourceFile();
         }
-        return sourceFile;
+        return effectiveValue;
     }
 
     private List<ClientEventAck.ConflictEntry> buildConflicts(ConfigEffectiveValueProvider provider, String key,
@@ -609,9 +610,12 @@ public class ClientEventQueryHandler {
 
         private final ConfigFileMetadata sourceFile;
 
-        ResolvedEntry(ClientEventAck.PropertyEntry entry, ConfigFileMetadata sourceFile) {
+        private final EffectiveValue.SourceKind sourceKind;
+
+        ResolvedEntry(ClientEventAck.PropertyEntry entry, EffectiveValue resolved) {
             this.entry = entry;
-            this.sourceFile = sourceFile;
+            this.sourceFile = resolved == null ? null : resolved.getSourceFile();
+            this.sourceKind = resolved == null ? EffectiveValue.SourceKind.UNKNOWN : resolved.getSourceKind();
         }
 
         ClientEventAck.PropertyEntry getEntry() {
@@ -620,6 +624,10 @@ public class ClientEventQueryHandler {
 
         ConfigFileMetadata getSourceFile() {
             return sourceFile;
+        }
+
+        EffectiveValue.SourceKind getSourceKind() {
+            return sourceKind;
         }
     }
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandler.java
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * 配置生效查询处理器，解析服务端 PUSH 指令并组装 ACK content JSON。
  * <p>
  * 任何分支都必须返回可发送的 JSON：服务端同步等待 ACK，静默会把它挂到超时。
- * 本类 INFO 只记文件坐标；PUSH/ACK 全文由连接器按 INFO 输出。
+ * 本类与连接器的日志均只记文件坐标与规模，不输出 PUSH/ACK 全文。
  *
  * @author evelynwei
  */
@@ -277,8 +277,59 @@ public class ClientEventQueryHandler {
         if (!entries.isEmpty() && snapshot.isEncrypted()) {
             setEncryptedProperties(ack, entries, snapshot);
         } else if (!entries.isEmpty()) {
-            ack.setProperties(entries);
+            // 明文 ACK：entries 是跨文件采集的，来自加密文件的值不得以明文回传或进入日志
+            ack.setProperties(stripEncryptedSourceValues(entries));
         }
+    }
+
+    /**
+     * 明文 ACK 前的脱敏。conflicts 与 effectiveValue 由 {@link ConfigEffectiveValueProvider} 跨全部
+     * 被监听文件采集，其中可能包含加密文件的值；本文件未加密时无密钥可用，只能去掉这些值，
+     * 仅保留「此处存在冲突」这一事实与来源坐标 —— 服务端定位冲突并不需要值本身。
+     *
+     * <p>局限：effectiveValue 的来源以 Spring property source 名标识，无法反查文件坐标，
+     * 因此只能在存在加密来源冲突项时一并去掉。彻底修复需采集侧（SCT provider）标记来源加密状态。
+     *
+     * @param entries 待回传的属性明细
+     * @return 原列表，元素已就地脱敏
+     */
+    private List<ClientEventAck.PropertyEntry> stripEncryptedSourceValues(
+            List<ClientEventAck.PropertyEntry> entries) {
+        for (ClientEventAck.PropertyEntry entry : entries) {
+            if (stripEncryptedConflictValues(entry)) {
+                entry.setEffectiveValue(null);
+            }
+        }
+        return entries;
+    }
+
+    private boolean stripEncryptedConflictValues(ClientEventAck.PropertyEntry entry) {
+        boolean stripped = false;
+        List<ClientEventAck.ConflictEntry> conflicts = entry.getConflicts();
+        if (conflicts != null) {
+            for (ClientEventAck.ConflictEntry conflict : conflicts) {
+                if (conflict != null && isEncryptedWatchedFile(conflict)) {
+                    conflict.setValue(null);
+                    stripped = true;
+                }
+            }
+        }
+        return stripped;
+    }
+
+    /**
+     * 判断冲突来源文件是否为加密配置。加密状态取自本地已监听文件的快照，不依赖采集侧上报。
+     */
+    private boolean isEncryptedWatchedFile(ClientEventAck.ConflictEntry conflict) {
+        ConfigFileMetadata metadata = new DefaultConfigFileMetadata(emptyIfNull(conflict.getNamespace()),
+                emptyIfNull(conflict.getGroup()), emptyIfNull(conflict.getFileName()));
+        RemoteConfigFileRepo repo = watchRegistry == null ? null : watchRegistry.getWatchedFile(metadata);
+        ConfigFileSnapshot snapshot = repo == null ? null : repo.getSnapshot();
+        return snapshot != null && snapshot.isEncrypted();
+    }
+
+    private String emptyIfNull(String value) {
+        return value == null ? "" : value;
     }
 
     private List<ClientEventAck.PropertyEntry> buildPropertyEntries(ConfigEffectiveValueProvider provider,

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/CompositeConfigFile.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/CompositeConfigFile.java
@@ -165,6 +165,27 @@ public class CompositeConfigFile implements ConfigKVFile {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * 组内**任一**子文件为加密配置即返回 true，是组维度的聚合判据。
+     *
+     * <p>组由多个文件合并而成，可能一部分加密一部分不加密，因此该方法只适合「这一组里是否存在
+     * 敏感数据」这类保守判断。需要逐值精确归因时请遍历 {@link #getConfigKVFiles()} 自行判断，
+     * 不要用这个聚合值。
+     *
+     * @return 存在加密子文件返回 true
+     */
+    @Override
+    public boolean isEncrypted() {
+        boolean encrypted = false;
+        for (ConfigKVFile configKVFile : configKVFiles) {
+            if (configKVFile.isEncrypted()) {
+                encrypted = true;
+                break;
+            }
+        }
+        return encrypted;
+    }
+
     @Override
     public void addChangeListener(ConfigFileChangeListener listener) {
         for (ConfigKVFile configKVFile : configKVFiles) {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
@@ -40,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -129,17 +130,24 @@ public class ConfigFilePersistentHandler {
      * @param configFile config file
      */
     public void saveConfigFile(ConfigFile configFile) {
-        int retryTimes = 0;
+        // 先定副本：拒绝落盘（会写出明文）时直接放弃，不进重试循环
+        ConfigFile persistCopy = copyForPersist(configFile);
+        if (persistCopy != null) {
+            saveWithRetry(configFile, persistCopy);
+        }
+    }
+
+    private void saveWithRetry(ConfigFile configFile, ConfigFile persistCopy) {
         String meta = configMeta(configFile);
+        int retryTimes = 0;
         LOG.info("start to save config file {}", meta);
         while (retryTimes <= maxWriteRetry) {
             retryTimes++;
-            Path path = doSaveConfigFile(configFile);
-            if (null == path) {
-                continue;
+            Path path = doSaveConfigFile(configFile, persistCopy);
+            if (null != path) {
+                LOG.info("end to save config file {} to {}", meta, path);
+                return;
             }
-            LOG.info("end to save config file {} to {}", meta, path);
-            return;
         }
         LOG.error("fail to persist config file {} after retry {}", meta, retryTimes);
     }
@@ -167,28 +175,38 @@ public class ConfigFilePersistentHandler {
      * 向服务端声明支持加密，因此 encrypted=true 不代表服务端真的返回了加密内容；而 sourceContent
      * 只在解密成功后被赋值，是「确实拿到并解开了密文」的可靠信号。
      *
+     * <p>解开过密文但拿不到密钥时返回 null 表示放弃落盘：此时 content 已是明文，落盘会把明文写到
+     * 磁盘上且标记为未加密，后续加载不再尝试解密，明文将静默留存。宁可没有缓存，也不能落明文。
+     *
      * @param source 业务内存对象
-     * @return 持久化副本
+     * @return 持久化副本；不应落盘时返回 null
      */
     private ConfigFile copyForPersist(ConfigFile source) {
-        ConfigFile copy = new ConfigFile(source.getNamespace(), source.getFileGroup(), source.getFileName());
-        copy.setVersion(source.getVersion());
-        copy.setName(source.getName());
-        copy.setMd5(source.getMd5());
-        copy.setEncrypted(source.isEncrypted());
-        copy.setEncryptAlgo(source.getEncryptAlgo());
-        copy.setReleaseTime(source.getReleaseTime());
-        copy.setDataKey(source.getDataKey());
+        ConfigFile copy = null;
         String cipherText = source.getSourceContent();
-        if (StringUtils.isNotBlank(cipherText) && StringUtils.isNotBlank(source.getDataKey())) {
-            // 加密配置：落盘密文态，content 与 sourceContent 一致以保持字段语义自洽
-            copy.setContent(cipherText);
-            copy.setSourceContent(cipherText);
-            copy.setCacheEncrypted(true);
+        boolean decrypted = StringUtils.isNotBlank(cipherText);
+        if (decrypted && StringUtils.isBlank(source.getDataKey())) {
+            LOG.error("config file {} was decrypted but data key is missing, skip persisting to avoid "
+                    + "writing plaintext to disk", configMeta(source));
         } else {
-            copy.setContent(source.getContent());
-            copy.setSourceContent(source.getSourceContent());
-            copy.setCacheEncrypted(false);
+            copy = new ConfigFile(source.getNamespace(), source.getFileGroup(), source.getFileName());
+            copy.setVersion(source.getVersion());
+            copy.setName(source.getName());
+            copy.setMd5(source.getMd5());
+            copy.setEncrypted(source.isEncrypted());
+            copy.setEncryptAlgo(source.getEncryptAlgo());
+            copy.setReleaseTime(source.getReleaseTime());
+            copy.setDataKey(source.getDataKey());
+            if (decrypted) {
+                // 加密配置：落盘密文态，content 与 sourceContent 一致以保持字段语义自洽
+                copy.setContent(cipherText);
+                copy.setSourceContent(cipherText);
+                copy.setCacheEncrypted(true);
+            } else {
+                copy.setContent(source.getContent());
+                copy.setSourceContent(source.getSourceContent());
+                copy.setCacheEncrypted(false);
+            }
         }
         return copy;
     }
@@ -204,7 +222,7 @@ public class ConfigFilePersistentHandler {
         }
     }
 
-    private void writeTmpFile(File persistTmpFile, File persistLockFile, ConfigFile configFile) throws IOException {
+    private void writeTmpFile(File persistTmpFile, File persistLockFile, ConfigFile persistCopy) throws IOException {
         try (RandomAccessFile raf = new RandomAccessFile(persistLockFile, "rw");
              FileChannel channel = raf.getChannel()) {
             FileLock lock = channel.tryLock();
@@ -214,21 +232,22 @@ public class ConfigFilePersistentHandler {
             }
             //执行保存
             try {
-                doWriteTmpFile(persistTmpFile, configFile);
+                doWriteTmpFile(persistTmpFile, persistCopy);
             } finally {
                 lock.release();
             }
         }
     }
 
-    private void doWriteTmpFile(File persistTmpFile, ConfigFile configFile) throws IOException {
+    private void doWriteTmpFile(File persistTmpFile, ConfigFile persistCopy) throws IOException {
         if (!persistTmpFile.exists()) {
             if (!persistTmpFile.createNewFile()) {
                 LOG.warn("tmp file {} already exists", persistTmpFile.getAbsolutePath());
             }
         }
-        // 先构造持久化副本（加密配置转为密文态），再序列化
-        ConfigFile persistCopy = copyForPersist(configFile);
+        //先收权限再写内容：否则会出现「内容已落盘、权限仍是 umask 默认」的窗口。
+        //ATOMIC_MOVE 保留 inode 与权限，最终缓存文件同样是 0600
+        restrictToOwnerOnly(persistTmpFile);
         try (FileOutputStream outputFile = new FileOutputStream(persistTmpFile)) {
             String jsonAsYaml = new YAMLMapper().writeValueAsString(persistCopy);
             outputFile.write(jsonAsYaml.getBytes(StandardCharsets.UTF_8));
@@ -236,7 +255,30 @@ public class ConfigFilePersistentHandler {
         }
     }
 
-    private Path doSaveConfigFile(ConfigFile configFile) {
+    /**
+     * 把缓存文件权限收紧到仅属主可读写。
+     *
+     * <p>加密配置的缓存文件里同时有密文和解开它的 dataKey：RSA 密钥对由 RSAService 每进程重新生成、
+     * 不落盘，服务端下发的包裹密钥重启后必然解不开，要支持重启后仍能用缓存降级就只能落明文 AES 密钥。
+     * 所以这份文件等同于凭据文件，按 ssh 私钥的方式用文件权限保护。
+     *
+     * <p>非 POSIX 文件系统（如 Windows）静默跳过，权限收紧失败也只告警不影响落盘。
+     *
+     * @param file 待收紧权限的文件
+     */
+    private void restrictToOwnerOnly(File file) {
+        Path path = file.toPath();
+        if (!path.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+            return;
+        }
+        try {
+            Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("rw-------"));
+        } catch (IOException | UnsupportedOperationException e) {
+            LOG.warn("fail to restrict permissions of cache file {}", path);
+        }
+    }
+
+    private Path doSaveConfigFile(ConfigFile configFile, ConfigFile persistCopy) {
         String fileName = configFileToFileName(configFile);
         String tmpFileName = fileName + ".tmp";
         String lockFileName = fileName + ".lock";
@@ -250,7 +292,7 @@ public class ConfigFilePersistentHandler {
                     LOG.warn("lock file {} already exists", persistLockFile.getAbsolutePath());
                 }
             }
-            writeTmpFile(persistTmpFile, persistLockFile, configFile);
+            writeTmpFile(persistTmpFile, persistLockFile, persistCopy);
             Files.move(FileSystems.getDefault().getPath(persistTmpFile.getAbsolutePath()),
                     persistPath, REPLACE_EXISTING, ATOMIC_MOVE);
         } catch (IOException e) {
@@ -332,14 +374,14 @@ public class ConfigFilePersistentHandler {
             if (dataKey != null) {
                 resConfigFile.setDataKey(dataKey.toString());
             }
-            // 历史缓存无 cacheEncrypted 字段，解析为 false 后走明文分支，天然向后兼容
+            // 历史缓存无 cacheEncrypted 字段，解析为 false 后走明文分支
             Object cacheEncrypted = jsonMap.get("cacheEncrypted");
             boolean isCacheEncrypted = cacheEncrypted != null && Boolean.parseBoolean(cacheEncrypted.toString());
             resConfigFile.setCacheEncrypted(isCacheEncrypted);
             if (isCacheEncrypted) {
                 return decryptCachedContent(resConfigFile, persistFile.getName());
             }
-            return resConfigFile;
+            return discardIfLegacyPlaintextOfEncryptedConfig(resConfigFile, encryptedValue, persistFile);
         } catch (IOException e) {
             LOG.warn("fail to read file :" + persistFile.getAbsoluteFile(), e);
             return null;
@@ -358,6 +400,41 @@ public class ConfigFilePersistentHandler {
                     LOG.warn("fail to close stream for :" + persistFile.getAbsoluteFile(), e);
                 }
             }
+        }
+    }
+
+    /**
+     * 丢弃「加密配置却落着明文」的历史缓存：本版本之前留下的文件没有 cacheEncrypted 标记，
+     * 若原样返回，明文会一直留在磁盘上。删除后由后续拉取重新落成密文态。
+     *
+     * @param resConfigFile 已完成字段回填的缓存对象
+     * @param encrypted 服务端标记的加密态
+     * @param persistFile 缓存文件
+     * @return 普通配置原样返回；加密配置的明文缓存返回 null
+     */
+    private ConfigFile discardIfLegacyPlaintextOfEncryptedConfig(ConfigFile resConfigFile, boolean encrypted,
+            File persistFile) {
+        ConfigFile result = resConfigFile;
+        if (encrypted) {
+            LOG.warn("cached config file {} is an encrypted config persisted as plaintext by an older version, "
+                    + "discard and delete it", persistFile.getName());
+            deletePlaintextCacheOfEncryptedConfig(persistFile);
+            result = null;
+        }
+        return result;
+    }
+
+    /**
+     * 删除「加密配置却落着明文」的历史缓存文件及其 lock 文件。删除失败只告警，不影响启动流程。
+     *
+     * @param persistFile 缓存文件
+     */
+    private void deletePlaintextCacheOfEncryptedConfig(File persistFile) {
+        try {
+            Files.deleteIfExists(persistFile.toPath());
+            Files.deleteIfExists(FileSystems.getDefault().getPath(persistFile.getAbsolutePath() + ".lock"));
+        } catch (IOException e) {
+            LOG.warn("fail to delete legacy plaintext cache file {}", persistFile.getName());
         }
     }
 

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
@@ -20,10 +20,13 @@ package com.tencent.polaris.configuration.client.internal;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.tencent.polaris.api.plugin.configuration.ConfigFile;
+import com.tencent.polaris.api.utils.ClassUtils;
+import com.tencent.polaris.api.utils.StringUtils;
 import com.tencent.polaris.api.utils.ThreadPoolUtils;
 import com.tencent.polaris.client.api.SDKContext;
 import com.tencent.polaris.client.util.NamedThreadFactory;
 import com.tencent.polaris.client.util.Utils;
+import com.tencent.polaris.encrypt.util.AESUtil;
 import com.tencent.polaris.factory.util.FileUtils;
 import com.tencent.polaris.logging.LoggerFactory;
 import org.slf4j.Logger;
@@ -37,6 +40,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -55,6 +59,10 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class ConfigFilePersistentHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConfigFilePersistentHandler.class);
+
+    private static final String ALGO_AES = "AES";
+
+    private static final String BOUNCY_CASTLE_PROVIDER = "org.bouncycastle.jce.provider.BouncyCastleProvider";
 
     private final String persistDirPath;
     private final int maxWriteRetry;
@@ -122,17 +130,67 @@ public class ConfigFilePersistentHandler {
      */
     public void saveConfigFile(ConfigFile configFile) {
         int retryTimes = 0;
-        LOG.info("start to save config file {}", configFile);
+        String meta = configMeta(configFile);
+        LOG.info("start to save config file {}", meta);
         while (retryTimes <= maxWriteRetry) {
             retryTimes++;
             Path path = doSaveConfigFile(configFile);
             if (null == path) {
                 continue;
             }
-            LOG.info("end to save config file {} to {}", configFile, path);
+            LOG.info("end to save config file {} to {}", meta, path);
             return;
         }
-        LOG.error("fail to persist config file {} after retry {}", configFile, retryTimes);
+        LOG.error("fail to persist config file {} after retry {}", meta, retryTimes);
+    }
+
+    /**
+     * 日志用元数据串，不含任何配置正文与密钥。
+     *
+     * @param configFile 配置文件
+     * @return 元数据串
+     */
+    private String configMeta(ConfigFile configFile) {
+        return String.format("[namespace=%s, fileGroup=%s, fileName=%s, version=%d, encrypted=%s]",
+                configFile.getNamespace(), configFile.getFileGroup(), configFile.getFileName(),
+                configFile.getVersion(), configFile.isEncrypted());
+    }
+
+    /**
+     * 创建持久化副本，与业务内存对象隔离，避免把业务正在使用的明文对象改成密文。
+     *
+     * <p>加密配置（sourceContent 与 dataKey 均非空）：content 取 sourceContent（服务端原始密文，
+     * 无需二次加密），dataKey 原样保留 Base64(明文 AES 密钥) 随文件持久化以支撑进程重启后解密，
+     * cacheEncrypted 置为 true。普通配置完全保持原有明文落盘行为。
+     *
+     * <p>判据用 sourceContent 而非 encrypted：加密 filter 在请求前就把 encrypted 置为 true 用于
+     * 向服务端声明支持加密，因此 encrypted=true 不代表服务端真的返回了加密内容；而 sourceContent
+     * 只在解密成功后被赋值，是「确实拿到并解开了密文」的可靠信号。
+     *
+     * @param source 业务内存对象
+     * @return 持久化副本
+     */
+    private ConfigFile copyForPersist(ConfigFile source) {
+        ConfigFile copy = new ConfigFile(source.getNamespace(), source.getFileGroup(), source.getFileName());
+        copy.setVersion(source.getVersion());
+        copy.setName(source.getName());
+        copy.setMd5(source.getMd5());
+        copy.setEncrypted(source.isEncrypted());
+        copy.setEncryptAlgo(source.getEncryptAlgo());
+        copy.setReleaseTime(source.getReleaseTime());
+        copy.setDataKey(source.getDataKey());
+        String cipherText = source.getSourceContent();
+        if (StringUtils.isNotBlank(cipherText) && StringUtils.isNotBlank(source.getDataKey())) {
+            // 加密配置：落盘密文态，content 与 sourceContent 一致以保持字段语义自洽
+            copy.setContent(cipherText);
+            copy.setSourceContent(cipherText);
+            copy.setCacheEncrypted(true);
+        } else {
+            copy.setContent(source.getContent());
+            copy.setSourceContent(source.getSourceContent());
+            copy.setCacheEncrypted(false);
+        }
+        return copy;
     }
 
     private static String configFileToFileName(ConfigFile configFile) {
@@ -169,8 +227,10 @@ public class ConfigFilePersistentHandler {
                 LOG.warn("tmp file {} already exists", persistTmpFile.getAbsolutePath());
             }
         }
+        // 先构造持久化副本（加密配置转为密文态），再序列化
+        ConfigFile persistCopy = copyForPersist(configFile);
         try (FileOutputStream outputFile = new FileOutputStream(persistTmpFile)) {
-            String jsonAsYaml = new YAMLMapper().writeValueAsString(configFile);
+            String jsonAsYaml = new YAMLMapper().writeValueAsString(persistCopy);
             outputFile.write(jsonAsYaml.getBytes(StandardCharsets.UTF_8));
             outputFile.flush();
         }
@@ -272,6 +332,13 @@ public class ConfigFilePersistentHandler {
             if (dataKey != null) {
                 resConfigFile.setDataKey(dataKey.toString());
             }
+            // 历史缓存无 cacheEncrypted 字段，解析为 false 后走明文分支，天然向后兼容
+            Object cacheEncrypted = jsonMap.get("cacheEncrypted");
+            boolean isCacheEncrypted = cacheEncrypted != null && Boolean.parseBoolean(cacheEncrypted.toString());
+            resConfigFile.setCacheEncrypted(isCacheEncrypted);
+            if (isCacheEncrypted) {
+                return decryptCachedContent(resConfigFile, persistFile.getName());
+            }
             return resConfigFile;
         } catch (IOException e) {
             LOG.warn("fail to read file :" + persistFile.getAbsoluteFile(), e);
@@ -291,6 +358,54 @@ public class ConfigFilePersistentHandler {
                     LOG.warn("fail to close stream for :" + persistFile.getAbsoluteFile(), e);
                 }
             }
+        }
+    }
+
+    /**
+     * 解密密文态缓存，进程重启后从磁盘取回密钥完成恢复。
+     *
+     * <p>cacheEncrypted=true 是本 SDK 自己写入的确定性标记，此时 content 一定是密文，因此任何
+     * 不确定因素一律返回 null（视为缓存不可用，由上层重试或降级），绝不把密文当明文交给业务。
+     *
+     * @param resConfigFile 已完成字段回填的缓存对象，content 为密文
+     * @param fileName 缓存文件名，仅用于日志定位
+     * @return 解密后的配置文件，失败返回 null
+     */
+    private ConfigFile decryptCachedContent(ConfigFile resConfigFile, String fileName) {
+        String dataKey = resConfigFile.getDataKey();
+        String algo = resConfigFile.getEncryptAlgo();
+        if (StringUtils.isBlank(dataKey)) {
+            LOG.error("cached config file {} marked as encrypted but dataKey is missing, discard this cache",
+                    fileName);
+            return null;
+        }
+        // 只认 AES：encryptAlgo 由本 SDK 写入，未知算法说明缓存来自不兼容版本；缺失则按 AES 兼容处理
+        if (StringUtils.isNotBlank(algo) && !ALGO_AES.equalsIgnoreCase(algo)) {
+            LOG.error("cached config file {} uses unsupported encrypt algo {}, discard this cache", fileName, algo);
+            return null;
+        }
+        // BouncyCastle 为可选依赖，缺失时加载 AESUtil 会抛 NoClassDefFoundError，须提前预判
+        if (!ClassUtils.isClassPresent(BOUNCY_CASTLE_PROVIDER)) {
+            LOG.error("cached config file {} is encrypted but bouncycastle is absent, discard this cache", fileName);
+            return null;
+        }
+        return doDecryptCachedContent(resConfigFile, fileName);
+    }
+
+    private ConfigFile doDecryptCachedContent(ConfigFile resConfigFile, String fileName) {
+        try {
+            byte[] aesKey = Base64.getDecoder().decode(resConfigFile.getDataKey());
+            String cipherText = resConfigFile.getContent();
+            String plainText = AESUtil.decrypt(cipherText, aesKey);
+            // 保留密文到 sourceContent，语义与远端拉取一致；content 交给业务的是明文
+            resConfigFile.setSourceContent(cipherText);
+            resConfigFile.setContent(plainText);
+            resConfigFile.setCacheEncrypted(false);
+            return resConfigFile;
+        } catch (Throwable t) {
+            // 捕 Throwable：密钥或算法相关失败可能以 Error 形式出现。不输出正文与密钥
+            LOG.error("fail to decrypt cached config file {}, error: {}", fileName, t.getMessage());
+            return null;
         }
     }
 

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
@@ -20,12 +20,12 @@ package com.tencent.polaris.configuration.client.internal;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.tencent.polaris.api.plugin.configuration.ConfigFile;
-import com.tencent.polaris.api.utils.ClassUtils;
 import com.tencent.polaris.api.utils.StringUtils;
 import com.tencent.polaris.api.utils.ThreadPoolUtils;
 import com.tencent.polaris.client.api.SDKContext;
 import com.tencent.polaris.client.util.NamedThreadFactory;
 import com.tencent.polaris.client.util.Utils;
+import com.tencent.polaris.encrypt.EncryptConstants;
 import com.tencent.polaris.encrypt.util.AESUtil;
 import com.tencent.polaris.factory.util.FileUtils;
 import com.tencent.polaris.logging.LoggerFactory;
@@ -60,10 +60,6 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 public class ConfigFilePersistentHandler {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConfigFilePersistentHandler.class);
-
-    private static final String ALGO_AES = "AES";
-
-    private static final String BOUNCY_CASTLE_PROVIDER = "org.bouncycastle.jce.provider.BouncyCastleProvider";
 
     private final String persistDirPath;
     private final int maxWriteRetry;
@@ -457,12 +453,12 @@ public class ConfigFilePersistentHandler {
             return null;
         }
         // 只认 AES：encryptAlgo 由本 SDK 写入，未知算法说明缓存来自不兼容版本；缺失则按 AES 兼容处理
-        if (StringUtils.isNotBlank(algo) && !ALGO_AES.equalsIgnoreCase(algo)) {
+        if (StringUtils.isNotBlank(algo) && !EncryptConstants.ALGO_AES.equalsIgnoreCase(algo)) {
             LOG.error("cached config file {} uses unsupported encrypt algo {}, discard this cache", fileName, algo);
             return null;
         }
         // BouncyCastle 为可选依赖，缺失时加载 AESUtil 会抛 NoClassDefFoundError，须提前预判
-        if (!ClassUtils.isClassPresent(BOUNCY_CASTLE_PROVIDER)) {
+        if (!EncryptConstants.isBouncyCastlePresent()) {
             LOG.error("cached config file {} is encrypted but bouncycastle is absent, discard this cache", fileName);
             return null;
         }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandler.java
@@ -338,65 +338,60 @@ public class ConfigFilePersistentHandler {
         if (null == persistFile || !persistFile.exists()) {
             return null;
         }
-        InputStream inputStream = null;
-        InputStreamReader reader = null;
-        Yaml yaml = new Yaml();
-        try {
-            inputStream = new FileInputStream(persistFile);
-            reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8);
-            ConfigFile resConfigFile = new ConfigFile(configFile.getNamespace(),
-                    configFile.getFileGroup(), configFile.getFileName());
-            Map<String, Object> jsonMap = yaml.load(reader);
-            resConfigFile.setContent(jsonMap.get("content").toString());
-            resConfigFile.setMd5(jsonMap.get("md5").toString());
-            resConfigFile.setVersion(Long.valueOf(String.valueOf(jsonMap.get("version"))));
-            Object name = jsonMap.get("name");
-            if (name != null) {
-                resConfigFile.setName(name.toString());
-            }
-            Object sourceContent = jsonMap.get("sourceContent");
-            if (sourceContent != null) {
-                resConfigFile.setSourceContent(sourceContent.toString());
-            }
-            Object encrypted = jsonMap.get("encrypted");
-            boolean encryptedValue = encrypted == null ? configFile.isEncrypted()
-                    : Boolean.parseBoolean(encrypted.toString());
-            resConfigFile.setEncrypted(encryptedValue);
-            Object encryptAlgo = jsonMap.get("encryptAlgo");
-            if (encryptAlgo != null) {
-                resConfigFile.setEncryptAlgo(encryptAlgo.toString());
-            }
-            Object dataKey = jsonMap.get("dataKey");
-            if (dataKey != null) {
-                resConfigFile.setDataKey(dataKey.toString());
-            }
-            // 历史缓存无 cacheEncrypted 字段，解析为 false 后走明文分支
-            Object cacheEncrypted = jsonMap.get("cacheEncrypted");
-            boolean isCacheEncrypted = cacheEncrypted != null && Boolean.parseBoolean(cacheEncrypted.toString());
-            resConfigFile.setCacheEncrypted(isCacheEncrypted);
-            if (isCacheEncrypted) {
-                return decryptCachedContent(resConfigFile, persistFile.getName());
-            }
-            return discardIfLegacyPlaintextOfEncryptedConfig(resConfigFile, encryptedValue, persistFile);
+        Map<String, Object> jsonMap;
+        // 先读完并关闭句柄再解析：Windows 不允许删除仍被打开的文件，历史明文缓存会删不掉
+        try (InputStream inputStream = new FileInputStream(persistFile);
+                InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
+            jsonMap = new Yaml().load(reader);
         } catch (IOException e) {
             LOG.warn("fail to read file :" + persistFile.getAbsoluteFile(), e);
             return null;
-        } finally {
-            if (null != reader) {
-                try {
-                    reader.close();
-                } catch (IOException e) {
-                    LOG.warn("fail to close reader for :" + persistFile.getAbsoluteFile(), e);
-                }
-            }
-            if (null != inputStream) {
-                try {
-                    inputStream.close();
-                } catch (IOException e) {
-                    LOG.warn("fail to close stream for :" + persistFile.getAbsoluteFile(), e);
-                }
-            }
         }
+        return parseConfigFile(jsonMap, persistFile, configFile);
+    }
+
+    /**
+     * 把缓存文件解析结果回填成配置对象，并按缓存形态决定解密、丢弃或原样返回。
+     *
+     * @param jsonMap 缓存文件解析出的键值
+     * @param persistFile 缓存文件，此时句柄已关闭，可安全删除
+     * @param configFile 发起加载的配置坐标
+     * @return 可用的配置文件；缓存不可用时返回 null
+     */
+    private ConfigFile parseConfigFile(Map<String, Object> jsonMap, File persistFile, ConfigFile configFile) {
+        ConfigFile resConfigFile = new ConfigFile(configFile.getNamespace(),
+                configFile.getFileGroup(), configFile.getFileName());
+        resConfigFile.setContent(jsonMap.get("content").toString());
+        resConfigFile.setMd5(jsonMap.get("md5").toString());
+        resConfigFile.setVersion(Long.valueOf(String.valueOf(jsonMap.get("version"))));
+        Object name = jsonMap.get("name");
+        if (name != null) {
+            resConfigFile.setName(name.toString());
+        }
+        Object sourceContent = jsonMap.get("sourceContent");
+        if (sourceContent != null) {
+            resConfigFile.setSourceContent(sourceContent.toString());
+        }
+        Object encrypted = jsonMap.get("encrypted");
+        boolean encryptedValue = encrypted == null ? configFile.isEncrypted()
+                : Boolean.parseBoolean(encrypted.toString());
+        resConfigFile.setEncrypted(encryptedValue);
+        Object encryptAlgo = jsonMap.get("encryptAlgo");
+        if (encryptAlgo != null) {
+            resConfigFile.setEncryptAlgo(encryptAlgo.toString());
+        }
+        Object dataKey = jsonMap.get("dataKey");
+        if (dataKey != null) {
+            resConfigFile.setDataKey(dataKey.toString());
+        }
+        // 历史缓存无 cacheEncrypted 字段，解析为 false 后走明文分支
+        Object cacheEncrypted = jsonMap.get("cacheEncrypted");
+        boolean isCacheEncrypted = cacheEncrypted != null && Boolean.parseBoolean(cacheEncrypted.toString());
+        resConfigFile.setCacheEncrypted(isCacheEncrypted);
+        if (isCacheEncrypted) {
+            return decryptCachedContent(resConfigFile, persistFile.getName());
+        }
+        return discardIfLegacyPlaintextOfEncryptedConfig(resConfigFile, encryptedValue, persistFile);
     }
 
     /**

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileRepo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileRepo.java
@@ -30,4 +30,15 @@ public interface ConfigFileRepo {
 
     void removeChangeListener(ConfigFileRepoChangeListener listener);
 
+    /**
+     * 当前配置在服务端是否为加密配置。
+     *
+     * <p>default 返回 false：本地文件、consul 等数据源不涉及服务端加密，只有远端仓库需要覆写。
+     *
+     * @return 加密配置返回 true
+     */
+    default boolean isEncrypted() {
+        return false;
+    }
+
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshot.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshot.java
@@ -42,25 +42,23 @@ public class ConfigFileSnapshot {
 
     private final String dataKey;
 
-    public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime) {
-        this(version, md5, content, effectiveTime, false, null, null);
-    }
-
-    public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime, String versionName) {
+    /**
+     * 全量构造器，是唯一给字段赋值的地方，其余构造器一律委托至此，
+     * 避免新增字段时漏改某个重载导致静默为 null。
+     *
+     * @param version 配置版本号
+     * @param versionName 配置版本名，无则为 null
+     * @param md5 源内容摘要
+     * @param content ACK/上报使用的源内容，加密配置为密文
+     * @param effectiveTime 本地生效时间戳
+     * @param encrypted 服务端是否为加密配置
+     * @param encryptAlgo 加密算法，非加密配置为 null
+     * @param dataKey Base64 明文 AES 密钥，非加密配置为 null
+     */
+    public ConfigFileSnapshot(long version, String versionName, String md5, String content, long effectiveTime,
+            boolean encrypted, String encryptAlgo, String dataKey) {
         this.version = version;
         this.versionName = versionName;
-        this.md5 = md5;
-        this.content = content;
-        this.effectiveTime = effectiveTime;
-        this.encrypted = false;
-        this.encryptAlgo = null;
-        this.dataKey = null;
-    }
-
-    public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime, boolean encrypted,
-            String encryptAlgo, String dataKey) {
-        this.version = version;
-        this.versionName = null;
         this.md5 = md5;
         this.content = content;
         this.effectiveTime = effectiveTime;
@@ -69,22 +67,30 @@ public class ConfigFileSnapshot {
         this.dataKey = dataKey;
     }
 
+    public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime) {
+        this(version, null, md5, content, effectiveTime, false, null, null);
+    }
+
+    public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime, String versionName) {
+        this(version, versionName, md5, content, effectiveTime, false, null, null);
+    }
+
+    public ConfigFileSnapshot(long version, String md5, String content, long effectiveTime, boolean encrypted,
+            String encryptAlgo, String dataKey) {
+        this(version, null, md5, content, effectiveTime, encrypted, encryptAlgo, dataKey);
+    }
+
     /**
      * 从同一份本地 ConfigFile 构造快照，version/versionName/md5 与加密字段同源。
+     * 生产链路只应使用该构造器，其余重载仅供测试按需拼装。
      *
      * @param configFile 本地配置
      * @param content ACK/上报使用的源内容
      * @param effectiveTime 生效时间戳
      */
     public ConfigFileSnapshot(ConfigFile configFile, String content, long effectiveTime) {
-        this.version = configFile.getVersion();
-        this.versionName = configFile.getName();
-        this.md5 = configFile.getMd5();
-        this.content = content;
-        this.effectiveTime = effectiveTime;
-        this.encrypted = configFile.isEncrypted();
-        this.encryptAlgo = configFile.getEncryptAlgo();
-        this.dataKey = configFile.getDataKey();
+        this(configFile.getVersion(), configFile.getName(), configFile.getMd5(), content, effectiveTime,
+                configFile.isEncrypted(), configFile.getEncryptAlgo(), configFile.getDataKey());
     }
 
     public long getVersion() {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigPropertiesFile.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigPropertiesFile.java
@@ -422,8 +422,10 @@ public class ConfigPropertiesFile extends DefaultConfigFile implements ConfigKVF
                     LOGGER.info("[Config] invoke config file change listener success. listener = {}, duration = {} ms",
                             listener.getClass().getName(), System.currentTimeMillis() - startTime);
                 } catch (Throwable t) {
-                    LOGGER.error("[Config] ailed to invoke config file change listener. listener = {}, event = {}",
-                            listener.getClass().getName(), event, t);
+                    // 只输出监听器、文件坐标与变更的 key 集合：ConfigPropertyChangeInfo 含变更前后的明文值
+                    LOGGER.error("[Config] failed to invoke config file change listener. listener = {}, "
+                                    + "file = {}/{}/{}, changedKeys = {}", listener.getClass().getName(),
+                            getNamespace(), getFileGroup(), getFileName(), event.changedKeys(), t);
                 }
             });
         }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigWatchReportRequestCustomizer.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigWatchReportRequestCustomizer.java
@@ -85,6 +85,25 @@ public class ConfigWatchReportRequestCustomizer implements ReportClientRequestCu
         return watchedFiles.get(toMetadataKey(metadata));
     }
 
+    /**
+     * 是否存在处于加密态的被监听配置文件。
+     * <p>
+     * 全部被监听文件均未加密时，任何生效值都不可能源自加密配置，明文 ACK 无需对生效值脱敏。
+     *
+     * @return 任一被监听文件为加密配置返回 true
+     */
+    public boolean hasEncryptedWatchedFile() {
+        boolean encrypted = false;
+        for (RemoteConfigFileRepo repo : watchedFiles.values()) {
+            ConfigFileSnapshot snapshot = repo.getSnapshot();
+            if (snapshot != null && snapshot.isEncrypted()) {
+                encrypted = true;
+                break;
+            }
+        }
+        return encrypted;
+    }
+
     private ConfigFileMetadata toMetadataKey(ConfigFileMetadata metadata) {
         return new DefaultConfigFileMetadata(metadata.getNamespace(), metadata.getFileGroup(), metadata.getFileName());
     }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigYamlFile.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/ConfigYamlFile.java
@@ -21,6 +21,8 @@ import com.tencent.polaris.api.config.configuration.ConfigFileConfig;
 import com.tencent.polaris.configuration.client.util.YamlParser;
 import com.tencent.polaris.logging.LoggerFactory;
 import org.slf4j.Logger;
+import org.yaml.snakeyaml.error.Mark;
+import org.yaml.snakeyaml.error.MarkedYAMLException;
 
 import java.util.Properties;
 
@@ -50,9 +52,29 @@ public class ConfigYamlFile extends ConfigPropertiesFile {
             String msg = String.format("[Config] failed to convert content to properties. namespace = %s, "
                             + "file group = %s, file name = %s",
                     getNamespace(), getFileGroup(), getFileName());
-            LOGGER.error(msg, t);
+            // 不把异常对象交给 logger：SnakeYAML 的 MarkedYAMLException 会把出错位置附近的原始
+            // YAML 行打进日志，加密配置在此已是解密后的明文。只输出异常类型与行列号用于定位
+            LOGGER.error("{}, error = {}", msg, describeParseFailure(t));
             throw new IllegalStateException(msg);
         }
         return properties;
+    }
+
+    /**
+     * 描述解析失败，只含异常类型与出错行列号，绝不含正文片段。
+     *
+     * @param t 解析异常
+     * @return 可安全写入日志的描述
+     */
+    private String describeParseFailure(Throwable t) {
+        String description = t.getClass().getName();
+        if (t instanceof MarkedYAMLException) {
+            Mark mark = ((MarkedYAMLException) t).getProblemMark();
+            if (mark != null) {
+                description = description + " at line " + (mark.getLine() + 1)
+                        + ", column " + (mark.getColumn() + 1);
+            }
+        }
+        return description;
     }
 }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/DefaultConfigFile.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/DefaultConfigFile.java
@@ -127,7 +127,10 @@ public class DefaultConfigFile extends DefaultConfigFileMetadata implements Conf
 
             return result;
         } catch (Throwable t) {
-            LOGGER.error("[Config] convert json file content to given class error. class type = {}", type, t);
+            // 不把异常对象交给 logger：反序列化异常的消息可能带上配置正文片段（如非法数值会
+            // 原样回显 For input string: "..."），加密配置在此已是解密后的明文
+            LOGGER.error("[Config] convert json file content to given class error. class type = {}, error = {}",
+                    type, t.getClass().getName());
         }
         return defaultValue;
     }
@@ -153,6 +156,11 @@ public class DefaultConfigFile extends DefaultConfigFileMetadata implements Conf
     @Override
     public String getMd5() {
         return configFileRepo.getMd5();
+    }
+
+    @Override
+    public boolean isEncrypted() {
+        return configFileRepo.isEncrypted();
     }
 
     @Override

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/DefaultConfigFile.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/DefaultConfigFile.java
@@ -203,8 +203,10 @@ public class DefaultConfigFile extends DefaultConfigFileMetadata implements Conf
                     LOGGER.info("[Config] invoke config file change listener success. listener = {}, duration = {} ms",
                             listener.getClass().getName(), System.currentTimeMillis() - startTime);
                 } catch (Throwable t) {
-                    LOGGER.error("[Config] failed to invoke config file change listener. listener = {}, event = {}",
-                            listener.getClass().getName(), event, t);
+                    // 只输出监听器与文件坐标、变更类型，不输出变更前后的配置正文
+                    LOGGER.error("[Config] failed to invoke config file change listener. listener = {}, "
+                                    + "file = {}/{}/{}, changeType = {}", listener.getClass().getName(),
+                            getNamespace(), getFileGroup(), getFileName(), event.getChangeType(), t);
                 }
             });
         }

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
@@ -285,6 +285,9 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
                 retryPolicy.fail();
 
                 retryTimes++;
+                if (retryTimes == 1 && fallbackToLocalCacheOnFirstMiss(pullConfigFileReq)) {
+                    return;
+                }
                 retryPolicy.executeDelay();
                 fallbackIfNecessary(retryTimes, pullConfigFileReq);
             } catch (Throwable t) {
@@ -292,10 +295,33 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
                 retryPolicy.fail();
 
                 retryTimes++;
+                if (retryTimes == 1 && fallbackToLocalCacheOnFirstMiss(pullConfigFileReq)) {
+                    return;
+                }
                 retryPolicy.executeDelay();
                 fallbackIfNecessary(retryTimes, pullConfigFileReq);
             }
         }
+    }
+
+    /**
+     * 内存尚未有配置时，远端第一次失败就尝试本地缓存。命中则跳过剩余退避重试，
+     * 避免 Spring config-data 阶段（早于 banner、同步阻塞）被 1/2/4 秒三次重试拖到分钟级。
+     * 内存已有配置时不走这条捷径，仍耗尽重试再决定是否覆盖。
+     *
+     * @param configFileReq 拉取请求
+     * @return 已用本地缓存填上内存则为 true
+     */
+    private boolean fallbackToLocalCacheOnFirstMiss(ConfigFile configFileReq) {
+        if (remoteConfigFile.get() != null) {
+            return false;
+        }
+        loadLocalCache(configFileReq, true);
+        if (remoteConfigFile.get() == null) {
+            return false;
+        }
+        LOGGER.warn("[Config] skip remaining pull retries, use local cache. config file = {}", configFileMetadata);
+        return true;
     }
 
     private void fallbackIfNecessary(final int retryTimes, ConfigFile configFileReq) {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
@@ -33,6 +33,7 @@ import com.tencent.polaris.configuration.client.util.ConfigFileUtils;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -45,6 +46,12 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
     private static final long INIT_VERSION = 0;
 
     private static final int PULL_CONFIG_RETRY_TIMES = 3;
+
+    /**
+     * 首次拉取失败降级本地缓存后，后台补拉的延迟秒数。留出一点时间让瞬时故障自行恢复，
+     * 同时远早于长轮询首轮（静默 5 秒起步，失败后最长退避 120 秒）。
+     */
+    private static final long CATCH_UP_PULL_DELAY_SECONDS = 3;
 
     private static ScheduledExecutorService pullExecutorService;
 
@@ -62,6 +69,8 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
     private final RetryPolicy retryPolicy;
     private ConfigFilePersistentHandler configFilePersistHandler;
     private final boolean fallbackToLocalCache;
+    //是否已安排过降级后的后台补拉，保证每个配置文件最多补拉一次
+    private final AtomicBoolean catchUpPullScheduled = new AtomicBoolean(false);
 
     private String token;
 
@@ -140,6 +149,16 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
         return remoteConfigFile.get() != null ? remoteConfigFile.get().getMd5() : "";
     }
 
+    /**
+     * {@code remoteConfigFile} 持有的是服务端下发的响应对象，其 encrypted 是逐文件真值，
+     * 可直接作为判据；请求侧对象会被加密过滤器无条件置 true，不可用。
+     */
+    @Override
+    public boolean isEncrypted() {
+        ConfigFile configFile = remoteConfigFile.get();
+        return configFile != null && configFile.isEncrypted();
+    }
+
     public long getConfigFileVersion() {
         if (remoteConfigFile.get() == null) {
             return INIT_VERSION;
@@ -199,6 +218,16 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
 
     @Override
     protected void doPull() {
+        doPull(PULL_CONFIG_RETRY_TIMES);
+    }
+
+    /**
+     * 拉取配置，失败后按指数退避重试至多 maxRetryTimes 次。
+     *
+     * @param maxRetryTimes 最大尝试次数。降级后的后台补拉传 1：只试一次且不退避，
+     *                      避免长时间占用所有配置文件共用的单线程拉取器
+     */
+    private void doPull(int maxRetryTimes) {
         long startTime = System.currentTimeMillis();
 
         ConfigFile pullConfigFileReq = new ConfigFile(configFileMetadata.getNamespace(),
@@ -210,7 +239,7 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
                 configFileMetadata, notifiedVersion.get());
 
         int retryTimes = 0;
-        while (retryTimes < PULL_CONFIG_RETRY_TIMES) {
+        while (retryTimes < maxRetryTimes) {
             try {
 
                 ConfigFileResponse response = configFileFilterChain
@@ -282,26 +311,41 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
                 //预期之外的状态码，重试
                 LOGGER.error("[Config] pull response without expected code. retry times = {}, code = {}", retryTimes,
                         response.getCode());
-                retryPolicy.fail();
 
                 retryTimes++;
-                if (retryTimes == 1 && fallbackToLocalCacheOnFirstMiss(pullConfigFileReq)) {
+                if (afterPullFailure(retryTimes, maxRetryTimes, pullConfigFileReq)) {
                     return;
                 }
-                retryPolicy.executeDelay();
-                fallbackIfNecessary(retryTimes, pullConfigFileReq);
             } catch (Throwable t) {
                 LOGGER.error("[Config] failed to pull config file. retry times = " + retryTimes, t);
-                retryPolicy.fail();
 
                 retryTimes++;
-                if (retryTimes == 1 && fallbackToLocalCacheOnFirstMiss(pullConfigFileReq)) {
+                if (afterPullFailure(retryTimes, maxRetryTimes, pullConfigFileReq)) {
                     return;
                 }
-                retryPolicy.executeDelay();
-                fallbackIfNecessary(retryTimes, pullConfigFileReq);
             }
         }
+    }
+
+    /**
+     * 单次拉取失败后的收尾：记退避、按需降级本地缓存。
+     *
+     * @param retryTimes 已尝试次数
+     * @param maxRetryTimes 最大尝试次数
+     * @param configFileReq 拉取请求
+     * @return 无需再重试返回 true
+     */
+    private boolean afterPullFailure(int retryTimes, int maxRetryTimes, ConfigFile configFileReq) {
+        retryPolicy.fail();
+        if (retryTimes == 1 && maxRetryTimes > 1 && fallbackToLocalCacheOnFirstMiss(configFileReq)) {
+            return true;
+        }
+        //只有确实还要再试才退避，否则最后一次失败后白等一轮，平白拉长启动阻塞
+        if (retryTimes < maxRetryTimes) {
+            retryPolicy.executeDelay();
+        }
+        fallbackIfNecessary(retryTimes, maxRetryTimes, configFileReq);
+        return false;
     }
 
     /**
@@ -321,15 +365,53 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
             return false;
         }
         LOGGER.warn("[Config] skip remaining pull retries, use local cache. config file = {}", configFileMetadata);
+        scheduleCatchUpPull();
         return true;
     }
 
-    private void fallbackIfNecessary(final int retryTimes, ConfigFile configFileReq) {
-        if (retryTimes >= PULL_CONFIG_RETRY_TIMES) {
-            LOGGER.info("[Config] failed to pull config file from remote.");
-            //重试次数超过上限，从本地缓存拉取
-            loadLocalCache(configFileReq, true);
+    /**
+     * 降级本地缓存后，在后台补拉一次远端配置，每个配置文件最多一次。
+     *
+     * <p>本地缓存可能已落后于服务端：启动期间可能已发布新版本，或已完成密钥轮换与旧凭据吊销。
+     * 跳过同步重试换来的启动速度，不应让客户端长期停留在旧配置上。只靠长轮询兜底不够及时——
+     * 它首轮前静默 5 秒，失败后按指数退避，最长可达 120 秒才再试一次。
+     *
+     * <p>补拉只试一次且不退避：拉取线程池是全部配置文件共用的单线程，长轮询感知到变更后也要
+     * 经它触发拉取，补拉不能把它占住。这一次没成也无妨，长轮询仍是最终兜底。
+     */
+    private void scheduleCatchUpPull() {
+        if (!catchUpPullScheduled.compareAndSet(false, true)) {
+            return;
         }
+        try {
+            pullExecutorService.schedule(this::catchUpPull, CATCH_UP_PULL_DELAY_SECONDS, TimeUnit.SECONDS);
+            LOGGER.info("[Config] catch up pull scheduled in {}s. config file = {}",
+                    CATCH_UP_PULL_DELAY_SECONDS, configFileMetadata);
+        } catch (RejectedExecutionException e) {
+            LOGGER.warn("[Config] catch up pull rejected, rely on long polling. config file = {}", configFileMetadata);
+        }
+    }
+
+    private void catchUpPull() {
+        try {
+            doPull(1);
+        } catch (Throwable t) {
+            LOGGER.warn("[Config] catch up pull failed, rely on long polling. config file = {}", configFileMetadata, t);
+        }
+    }
+
+    private void fallbackIfNecessary(final int retryTimes, int maxRetryTimes, ConfigFile configFileReq) {
+        if (retryTimes < maxRetryTimes) {
+            return;
+        }
+        //内存已有配置（含此前的降级结果），本地缓存不会比它更新，重复加载只会多发一次无意义的变更通知
+        if (remoteConfigFile.get() != null) {
+            LOGGER.info("[Config] failed to pull config file from remote, keep current config in memory.");
+            return;
+        }
+        LOGGER.info("[Config] failed to pull config file from remote.");
+        //重试次数超过上限，从本地缓存拉取
+        loadLocalCache(configFileReq, true);
     }
 
     private void fallbackIfNecessaryWhenStartingUp(ConfigFile configFileReq) {

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepo.java
@@ -326,11 +326,15 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
         if (fallbackToLocalCache) {
             ConfigFile configFileRes = configFilePersistHandler.loadPersistedConfigFile(configFileReq, needRetry);
             if (configFileRes != null) {
-                LOGGER.info("[Config] load local cache success.{}.", configFileRes);
+                LOGGER.info("[Config] load local cache success. namespace={}, fileGroup={}, fileName={}, "
+                                + "version={}, encrypted={}", configFileRes.getNamespace(),
+                        configFileRes.getFileGroup(), configFileRes.getFileName(), configFileRes.getVersion(),
+                        configFileRes.isEncrypted());
                 updateRemoteConfigFile(configFileRes);
                 return;
             }
-            LOGGER.info("[Config] load local cache fail.{}.", configFileReq);
+            LOGGER.info("[Config] load local cache fail. namespace={}, fileGroup={}, fileName={}",
+                    configFileReq.getNamespace(), configFileReq.getFileGroup(), configFileReq.getFileName());
         }
     }
 
@@ -391,6 +395,7 @@ public class RemoteConfigFileRepo extends AbstractConfigFileRepo {
         configFile.setPublicKey(sourceConfigFile.getPublicKey());
         configFile.setDataKey(sourceConfigFile.getDataKey());
         configFile.setEncryptAlgo(sourceConfigFile.getEncryptAlgo());
+        // 不复制 cacheEncrypted：业务内存对象恒为明文态
         return configFile;
     }
 

--- a/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/util/YamlParser.java
+++ b/polaris-configuration/polaris-configuration-client/src/main/java/com/tencent/polaris/configuration/client/util/YamlParser.java
@@ -57,7 +57,8 @@ public class YamlParser {
     private boolean process(MatchCallback callback, Yaml yaml, String content) {
         int count = 0;
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("[Config] Loading from YAML: " + content);
+            // 不输出正文：加密配置在此已是解密后的明文
+            LOGGER.debug("[Config] loading from YAML, length = {}", content == null ? 0 : content.length());
         }
         for (Object object : yaml.loadAll(content)) {
             if (object != null && process(asMap(object), callback)) {
@@ -65,8 +66,8 @@ public class YamlParser {
             }
         }
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("[Config] Loaded " + count + " document" + (count > 1 ? "s" : "") + " from YAML resource: "
-                    + content);
+            LOGGER.debug("[Config] loaded {} document(s) from YAML resource, length = {}",
+                    count, content == null ? 0 : content.length());
         }
         return (count > 0);
     }
@@ -103,7 +104,8 @@ public class YamlParser {
         properties.putAll(getFlattenedMap(map));
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("[Config] Merging document (no matchers set): " + map);
+            // 不输出 map 内容：value 为解密后的明文，只输出 key 集合
+            LOGGER.debug("[Config] merging document (no matchers set), keys = {}", properties.keySet());
         }
         callback.process(properties, map);
         return true;

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/LogCapture.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/LogCapture.java
@@ -1,0 +1,102 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.configuration.client;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 测试用日志捕获器，用于断言日志中不含配置正文与密钥。
+ *
+ * <p>用法：
+ * <pre>
+ * try (LogCapture capture = LogCapture.attach(TargetClass.class, Level.INFO)) {
+ *     // 触发被测逻辑
+ *     assertThat(capture.text()).doesNotContain(secret);
+ * }
+ * </pre>
+ *
+ * @author evelynwei
+ */
+public final class LogCapture implements AutoCloseable {
+
+    private final Logger logger;
+
+    private final ListAppender<ILoggingEvent> appender;
+
+    private final Level originalLevel;
+
+    private LogCapture(Logger logger, ListAppender<ILoggingEvent> appender, Level originalLevel) {
+        this.logger = logger;
+        this.appender = appender;
+        this.originalLevel = originalLevel;
+    }
+
+    /**
+     * 给目标类的 logger 挂上捕获器，并临时调整级别。
+     *
+     * @param target 目标类，须与被测代码 getLogger 的入参一致
+     * @param level 捕获期间生效的日志级别
+     * @return 捕获器，用完须 close 以摘除 appender 并还原级别
+     */
+    public static LogCapture attach(Class<?> target, Level level) {
+        // 先经 polaris 的 LoggerFactory 取一次，确保其日志配置初始化早于挂载 appender
+        com.tencent.polaris.logging.LoggerFactory.getLogger(target);
+        Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(target);
+        Level originalLevel = logger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.setLevel(level);
+        logger.addAppender(appender);
+        return new LogCapture(logger, appender, originalLevel);
+    }
+
+    /**
+     * 已捕获的日志消息（已完成占位符替换）。
+     *
+     * @return 消息列表
+     */
+    public List<String> messages() {
+        List<String> messages = new ArrayList<>(appender.list.size());
+        for (ILoggingEvent event : appender.list) {
+            messages.add(event.getFormattedMessage());
+        }
+        return messages;
+    }
+
+    /**
+     * 已捕获日志的合并文本，便于做 contains 断言。
+     *
+     * @return 以换行连接的全部消息
+     */
+    public String text() {
+        return String.join("\n", messages());
+    }
+
+    @Override
+    public void close() {
+        logger.detachAppender(appender);
+        appender.stop();
+        logger.setLevel(originalLevel);
+    }
+}

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
@@ -616,6 +616,78 @@ public class ClientEventQueryHandlerTest {
     }
 
     /**
+     * 测试目的：加密文件的值不得经由未加密文件的明文 ACK 外泄。
+     * 测试场景：未加密文件 A 与加密文件 B 均被监听且含同名 key，A 的冲突项来自 B。
+     * 验证内容：ACK 全文不含 B 的敏感值，冲突项保留来源坐标但不带 value，A 自身的 file_value 保留。
+     */
+    @Test
+    public void testConflictValueFromEncryptedFileIsStripped() {
+        // Arrange
+        String sensitiveValue = "root-password-from-encrypted-file";
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any()))
+                .thenReturn(new EffectiveValue("local", "local", "polaris:ns/g/plain.yaml"));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(
+                Collections.singletonList(new ConfigKeyConflict("ns", "g", "secret.yaml", sensitiveValue)));
+        handler.registerProvider(provider);
+
+        // Act
+        String ackJson = handler.onPush(1, pushJson("ns", "g", "plain.yaml"));
+
+        // Assert
+        assertThat(ackJson).doesNotContain(sensitiveValue);
+        JsonObject prop = ackOf(ackJson).getAsJsonArray("properties").get(0).getAsJsonObject();
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+        JsonObject conflictJson = prop.getAsJsonArray("conflicts").get(0).getAsJsonObject();
+        assertThat(conflictJson.get("file_name").getAsString()).isEqualTo("secret.yaml");
+        assertThat(conflictJson.has("value")).isFalse();
+    }
+
+    /**
+     * 测试目的：生效值来自加密文件时同样不以明文进入未加密文件的 ACK。
+     * 测试场景：未加密文件 A 的 key 被加密文件 B 覆盖，effectiveValue 即 B 的敏感值。
+     * 验证内容：ACK 无 effective_value 字段且全文不含敏感值。
+     */
+    @Test
+    public void testEffectiveValueFromEncryptedFileIsStripped() {
+        // Arrange
+        String sensitiveValue = "effective-secret-from-encrypted-file";
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any()))
+                .thenReturn(new EffectiveValue("local", sensitiveValue, "polaris:ns/g/secret.yaml"));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(
+                Collections.singletonList(new ConfigKeyConflict("ns", "g", "secret.yaml", sensitiveValue)));
+        handler.registerProvider(provider);
+
+        // Act
+        String ackJson = handler.onPush(1, pushJson("ns", "g", "plain.yaml"));
+
+        // Assert
+        assertThat(ackJson).doesNotContain(sensitiveValue);
+        JsonObject prop = ackOf(ackJson).getAsJsonArray("properties").get(0).getAsJsonObject();
+        assertThat(prop.has("effective_value")).isFalse();
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+    }
+
+    /**
+     * 注册一个加密态的被监听文件，仅用于校验冲突来源的加密判定。
+     */
+    private void registerEncryptedWatched(String namespace, String group, String fileName) {
+        RemoteConfigFileRepo repo = mock(RemoteConfigFileRepo.class);
+        ConfigFileMetadata metadata = new DefaultConfigFileMetadata(namespace, group, fileName);
+        when(repo.getConfigFileMetadata()).thenReturn(metadata);
+        when(repo.getSnapshot()).thenReturn(new ConfigFileSnapshot(9, "cipher-md5", "cipher-content", 100L,
+                true, "AES", "UDEyMzQ1Njc4OTAxMjM0NQ=="));
+        watchRegistry.register(repo);
+    }
+
+    /**
      * 测试目的：version=0/md5="" 时字段省略，对齐 Go 的 omitempty。
      * 测试场景：已拉取但 version=0、md5 为空。
      * 验证内容：ACK 无 version、无 md5 字段。

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
@@ -616,14 +616,14 @@ public class ClientEventQueryHandlerTest {
     }
 
     /**
-     * 测试目的：加密文件的值不得经由未加密文件的明文 ACK 外泄。
+     * 测试目的：配置冲突回传冲突文件该 key 的 file_value，加密来源不清空，供控制台展示。
      * 测试场景：未加密文件 A 与加密文件 B 均被监听且含同名 key，A 的冲突项来自 B。
-     * 验证内容：ACK 全文不含 B 的敏感值，冲突项保留来源坐标但不带 value，A 自身的 file_value 保留。
+     * 验证内容：冲突项保留来源坐标且 value 为 B 的 file_value；A 自身的 file_value 保留。
      */
     @Test
-    public void testConflictValueFromEncryptedFileIsStripped() {
+    public void testConflictValueFromEncryptedFileIsKept() {
         // Arrange
-        String sensitiveValue = "root-password-from-encrypted-file";
+        String secretFileValue = "root-password-from-encrypted-file";
         registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
         registerEncryptedWatched("ns", "g", "secret.yaml");
         ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
@@ -631,25 +631,24 @@ public class ClientEventQueryHandlerTest {
         when(provider.resolve(any(String.class), any()))
                 .thenReturn(new EffectiveValue("local", "local", "polaris:ns/g/plain.yaml"));
         when(provider.resolveConflicts(any(String.class), any())).thenReturn(
-                Collections.singletonList(new ConfigKeyConflict("ns", "g", "secret.yaml", sensitiveValue)));
+                Collections.singletonList(new ConfigKeyConflict("ns", "g", "secret.yaml", secretFileValue)));
         handler.registerProvider(provider);
 
         // Act
-        String ackJson = handler.onPush(1, pushJson("ns", "g", "plain.yaml"));
+        JsonObject prop = ackOf(handler.onPush(1, pushJson("ns", "g", "plain.yaml")))
+                .getAsJsonArray("properties").get(0).getAsJsonObject();
 
         // Assert
-        assertThat(ackJson).doesNotContain(sensitiveValue);
-        JsonObject prop = ackOf(ackJson).getAsJsonArray("properties").get(0).getAsJsonObject();
         assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
         JsonObject conflictJson = prop.getAsJsonArray("conflicts").get(0).getAsJsonObject();
         assertThat(conflictJson.get("file_name").getAsString()).isEqualTo("secret.yaml");
-        assertThat(conflictJson.has("value")).isFalse();
+        assertThat(conflictJson.get("value").getAsString()).isEqualTo(secretFileValue);
     }
 
     /**
-     * 测试目的：生效值来自加密文件时同样不以明文进入未加密文件的 ACK。
-     * 测试场景：未加密文件 A 的 key 被加密文件 B 覆盖，effectiveValue 即 B 的敏感值。
-     * 验证内容：ACK 无 effective_value 字段且全文不含敏感值。
+     * 测试目的：生效值来自加密文件时不以明文进入未加密文件 ACK 的 effective_value。
+     * 测试场景：未加密文件 A 的 key 被加密文件 B 覆盖，effectiveValue 即 B 的敏感值；冲突项仍带 B 的 file_value。
+     * 验证内容：ACK 无 effective_value；conflicts 仍回传冲突文件的 file_value。
      */
     @Test
     public void testEffectiveValueFromEncryptedFileIsStripped() {
@@ -666,13 +665,14 @@ public class ClientEventQueryHandlerTest {
         handler.registerProvider(provider);
 
         // Act
-        String ackJson = handler.onPush(1, pushJson("ns", "g", "plain.yaml"));
+        JsonObject prop = ackOf(handler.onPush(1, pushJson("ns", "g", "plain.yaml")))
+                .getAsJsonArray("properties").get(0).getAsJsonObject();
 
         // Assert
-        assertThat(ackJson).doesNotContain(sensitiveValue);
-        JsonObject prop = ackOf(ackJson).getAsJsonArray("properties").get(0).getAsJsonObject();
         assertThat(prop.has("effective_value")).isFalse();
         assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+        assertThat(prop.getAsJsonArray("conflicts").get(0).getAsJsonObject().get("value").getAsString())
+                .isEqualTo(sensitiveValue);
     }
 
     /**

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
@@ -815,6 +815,61 @@ public class ClientEventQueryHandlerTest {
     }
 
     /**
+     * 测试目的：来源明确不是 polaris 配置文件时保留生效值，外部覆盖的生效查询不被加密文件牵连。
+     * 测试场景：生效值来自命令行，采集侧给出 EXTERNAL 归因（无坐标），环境中存在加密文件。
+     * 验证内容：effective_value 原样保留 —— 此前该场景被 fail-closed 误伤。
+     */
+    @Test
+    public void testEffectiveValueKeptWhenSourceIsExternal() {
+        // Arrange
+        registerWatched("ns", "g", "plain.yaml", "server.port: 8080", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("server.port"));
+        when(provider.resolve(any(String.class), any())).thenReturn(new EffectiveValue("8080", "9090",
+                "commandLineArgs", null, EffectiveValue.SourceKind.EXTERNAL));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        // Act
+        JsonObject prop = ackOf(handler.onPush(1, pushJson("ns", "g", "plain.yaml")))
+                .getAsJsonArray("properties").get(0).getAsJsonObject();
+
+        // Assert
+        assertThat(prop.get("effective_value").getAsString()).isEqualTo("9090");
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("8080");
+        assertThat(prop.get("property_source").getAsString()).isEqualTo("commandLineArgs");
+    }
+
+    /**
+     * 测试目的：声明为 polaris 来源却没给坐标时不得放行，仍走 fail-closed。
+     * 测试场景：采集侧传 POLARIS_FILE 但坐标为 null，环境中存在加密文件且生效值被覆盖。
+     * 验证内容：归因被降级为 UNKNOWN，effective_value 仍被省略。
+     */
+    @Test
+    public void testEffectiveValueStrippedWhenPolarisKindMissesCoordinate() {
+        // Arrange
+        String sensitiveValue = "secret-without-coordinate";
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any())).thenReturn(new EffectiveValue("local", sensitiveValue,
+                "polaris:ns/g/secret.yaml", null, EffectiveValue.SourceKind.POLARIS_FILE));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        // Act
+        String ackJson = handler.onPush(1, pushJson("ns", "g", "plain.yaml"));
+
+        // Assert
+        assertThat(ackJson).doesNotContain(sensitiveValue);
+        JsonObject prop = ackOf(ackJson).getAsJsonArray("properties").get(0).getAsJsonObject();
+        assertThat(prop.has("effective_value")).isFalse();
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+    }
+
+    /**
      * 注册一个加密态的被监听文件，仅用于校验冲突来源的加密判定。
      */
     private void registerEncryptedWatched(String namespace, String group, String fileName) {

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ClientEventQueryHandlerTest.java
@@ -676,6 +676,145 @@ public class ClientEventQueryHandlerTest {
     }
 
     /**
+     * 测试目的：生效值被覆盖但无冲突项时，仍不以明文回传（fail-closed）。
+     * 测试场景：监听未加密文件 A 与加密文件 B，A 的 key 被覆盖，resolveConflicts 返回空列表。
+     * 验证内容：ACK 全文不含敏感值且无 effective_value，file_value 与冲突事实仍保留。
+     */
+    @Test
+    public void testEffectiveValueStrippedWhenNoConflictReported() {
+        // Arrange
+        String sensitiveValue = "overridden-secret-without-conflict";
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any()))
+                .thenReturn(new EffectiveValue("local", sensitiveValue, "polaris:ns/g/secret.yaml"));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        // Act
+        String ackJson = handler.onPush(1, pushJson("ns", "g", "plain.yaml"));
+
+        // Assert
+        assertThat(ackJson).doesNotContain(sensitiveValue);
+        JsonObject prop = ackOf(ackJson).getAsJsonArray("properties").get(0).getAsJsonObject();
+        assertThat(prop.has("effective_value")).isFalse();
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+        assertThat(prop.get("property_source").getAsString()).isEqualTo("polaris:ns/g/secret.yaml");
+    }
+
+    /**
+     * 测试目的：生效值即本文件自身明文时不做脱敏，避免误伤诊断信息。
+     * 测试场景：存在加密态被监听文件，但目标 key 的生效值与 file_value 一致，冲突来自未加密文件。
+     * 验证内容：effective_value 保留，未加密来源的冲突值同样保留。
+     */
+    @Test
+    public void testEffectiveValueKeptWhenSameAsFileValue() {
+        // Arrange
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any()))
+                .thenReturn(new EffectiveValue("local", "local", "polaris:ns/g/plain.yaml"));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(
+                Collections.singletonList(new ConfigKeyConflict("ns", "g", "other.yaml", "other-plain")));
+        handler.registerProvider(provider);
+
+        // Act
+        JsonObject prop = ackOf(handler.onPush(1, pushJson("ns", "g", "plain.yaml")))
+                .getAsJsonArray("properties").get(0).getAsJsonObject();
+
+        // Assert
+        assertThat(prop.get("effective_value").getAsString()).isEqualTo("local");
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+        assertThat(prop.getAsJsonArray("conflicts").get(0).getAsJsonObject().get("value").getAsString())
+                .isEqualTo("other-plain");
+    }
+
+    /**
+     * 测试目的：采集侧给出加密来源坐标时，按坐标精确省略生效值。
+     * 测试场景：目标文件未加密，生效值来源坐标指向加密文件 secret.yaml，且无冲突项。
+     * 验证内容：ACK 全文不含敏感值且无 effective_value，file_value 与 property_source 保留。
+     */
+    @Test
+    public void testEffectiveValueStrippedBySourceFileCoordinate() {
+        // Arrange
+        String sensitiveValue = "overridden-by-encrypted-source";
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any())).thenReturn(new EffectiveValue("local", sensitiveValue,
+                "polaris:ns/g/secret.yaml", new DefaultConfigFileMetadata("ns", "g", "secret.yaml")));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        // Act
+        String ackJson = handler.onPush(1, pushJson("ns", "g", "plain.yaml"));
+
+        // Assert
+        assertThat(ackJson).doesNotContain(sensitiveValue);
+        JsonObject prop = ackOf(ackJson).getAsJsonArray("properties").get(0).getAsJsonObject();
+        assertThat(prop.has("effective_value")).isFalse();
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+        assertThat(prop.get("property_source").getAsString()).isEqualTo("polaris:ns/g/secret.yaml");
+    }
+
+    /**
+     * 测试目的：来源坐标指向未加密文件时保留生效值，配置生效查询不受其他加密文件牵连。
+     * 测试场景：环境中存在加密文件 secret.yaml，但生效值来源坐标指向未加密的 other.yaml。
+     * 验证内容：effective_value 原样保留 —— 这是相对 fail-closed 的核心收益。
+     */
+    @Test
+    public void testEffectiveValueKeptWhenSourceFileNotEncrypted() {
+        // Arrange
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerWatched("ns", "g", "other.yaml", "db.password: from-other", 2, "md5-other", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any())).thenReturn(new EffectiveValue("local", "from-other",
+                "polaris:ns/g/other.yaml", new DefaultConfigFileMetadata("ns", "g", "other.yaml")));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        // Act
+        JsonObject prop = ackOf(handler.onPush(1, pushJson("ns", "g", "plain.yaml")))
+                .getAsJsonArray("properties").get(0).getAsJsonObject();
+
+        // Assert
+        assertThat(prop.get("effective_value").getAsString()).isEqualTo("from-other");
+        assertThat(prop.get("file_value").getAsString()).isEqualTo("local");
+    }
+
+    /**
+     * 测试目的：来源坐标不是被监听的 polaris 配置文件时保留生效值。
+     * 测试场景：生效值来自环境变量，坐标给出但不在被监听集合内。
+     * 验证内容：查不到快照即视为非加密，effective_value 保留。
+     */
+    @Test
+    public void testEffectiveValueKeptWhenSourceFileNotWatched() {
+        // Arrange
+        registerWatched("ns", "g", "plain.yaml", "db.password: local", 1, "md5-plain", 100L);
+        registerEncryptedWatched("ns", "g", "secret.yaml");
+        ConfigEffectiveValueProvider provider = mock(ConfigEffectiveValueProvider.class);
+        when(provider.getKeys(any())).thenReturn(Collections.singletonList("db.password"));
+        when(provider.resolve(any(String.class), any())).thenReturn(new EffectiveValue("local", "from-env",
+                "systemEnvironment", new DefaultConfigFileMetadata("ns", "g", "not-watched.yaml")));
+        when(provider.resolveConflicts(any(String.class), any())).thenReturn(Collections.emptyList());
+        handler.registerProvider(provider);
+
+        // Act
+        JsonObject prop = ackOf(handler.onPush(1, pushJson("ns", "g", "plain.yaml")))
+                .getAsJsonArray("properties").get(0).getAsJsonObject();
+
+        // Assert
+        assertThat(prop.get("effective_value").getAsString()).isEqualTo("from-env");
+    }
+
+    /**
      * 注册一个加密态的被监听文件，仅用于校验冲突来源的加密判定。
      */
     private void registerEncryptedWatched(String namespace, String group, String fileName) {

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandlerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandlerTest.java
@@ -38,9 +38,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Base64;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -58,6 +60,12 @@ public class ConfigFilePersistentHandlerTest {
     private static final String FILE_NAME = "biz-config";
 
     private static final String PLAIN_CONTENT = "jdbc.password=very-secret-value";
+
+    /**
+     * 固定的错误密钥，供「密钥不匹配」用例使用，避免随机密钥带来的偶发通过。
+     */
+    private static final byte[] MISMATCHED_AES_KEY = new byte[] {
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
     private static final long VERSION = 100L;
 
@@ -190,12 +198,12 @@ public class ConfigFilePersistentHandlerTest {
     }
 
     /**
-     * 测试目的：验证不会产生「有密文无密钥」的不可解缓存。
+     * 测试目的：验证解开过密文却拿不到密钥时放弃落盘，绝不把明文写到磁盘。
      * 测试场景：sourceContent 非空但 dataKey 缺失（解密链路异常）。
-     * 验证内容：走明文落盘分支，cacheEncrypted 为 false，读回仍是明文。
+     * 验证内容：缓存文件根本没被创建，读回为 null，磁盘上不存在明文。
      */
     @Test
-    public void testSaveEncryptedConfigFileWithoutDataKeyFallsBackToPlain() throws IOException {
+    public void testSaveEncryptedConfigFileWithoutDataKeySkipsPersist() {
         // Arrange
         ConfigFile configFile = assembleEncryptedConfigFile();
         configFile.setDataKey(null);
@@ -205,20 +213,55 @@ public class ConfigFilePersistentHandlerTest {
         ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
 
         // Assert
-        assertThat(readPersistedText()).contains("cacheEncrypted: false");
-        assertThat(loaded).isNotNull();
-        assertThat(loaded.getContent()).isEqualTo(PLAIN_CONTENT);
+        assertThat(cacheFilePath()).as("plaintext must not be persisted").doesNotExist();
+        assertThat(loaded).isNull();
     }
 
     /**
-     * 测试目的：验证对历史明文缓存的向后兼容。
-     * 测试场景：旧版本写入的缓存文件无 cacheEncrypted 字段，content 为明文但 dataKey 存在。
-     * 验证内容：按明文原样返回，不触发解密。
+     * 测试目的：验证缓存文件权限收紧到仅属主可读写。
+     * 测试场景：加密配置落盘，文件内同时有密文与解开它的 dataKey，等同于凭据文件。
+     * 验证内容：POSIX 文件系统下权限为 rw-------。
      */
     @Test
-    public void testLoadLegacyPlainCacheFile() throws IOException {
+    public void testPersistedCacheFileIsOwnerReadableOnly() throws IOException {
+        // Arrange
+        Path path = cacheFilePath();
+        assumeTrue(path.getFileSystem().supportedFileAttributeViews().contains("posix"));
+
+        // Act
+        handler.saveConfigFile(assembleEncryptedConfigFile());
+
+        // Assert
+        assertThat(PosixFilePermissions.toString(Files.getPosixFilePermissions(path))).isEqualTo("rw-------");
+    }
+
+    /**
+     * 测试目的：验证升级前留下的「加密配置却落明文」的缓存会被丢弃，不让明文长期留存。
+     * 测试场景：旧版本写入的缓存文件 encrypted=true、content 为明文、无 cacheEncrypted 字段。
+     * 验证内容：返回 null 且缓存文件被删除，交由后续拉取重新落成密文态。
+     */
+    @Test
+    public void testLoadLegacyPlaintextCacheOfEncryptedConfigIsDiscarded() throws IOException {
         // Arrange
         writeCacheFile(PLAIN_CONTENT, Base64.getEncoder().encodeToString(aesKey), "AES", null);
+
+        // Act
+        ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
+
+        // Assert
+        assertThat(loaded).isNull();
+        assertThat(cacheFilePath()).as("legacy plaintext cache must be deleted").doesNotExist();
+    }
+
+    /**
+     * 测试目的：验证未开启加密的场景行为完全不变。
+     * 测试场景：历史缓存文件 encrypted=false、content 为明文、无 cacheEncrypted 字段。
+     * 验证内容：按明文原样返回，不丢弃、不删除、不触发解密。
+     */
+    @Test
+    public void testLoadLegacyPlainCacheOfPlainConfigStillLoads() throws IOException {
+        // Arrange
+        writeCacheFile(PLAIN_CONTENT, null, null, null, false);
 
         // Act
         ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
@@ -227,6 +270,7 @@ public class ConfigFilePersistentHandlerTest {
         assertThat(loaded).isNotNull();
         assertThat(loaded.getContent()).isEqualTo(PLAIN_CONTENT);
         assertThat(loaded.isCacheEncrypted()).isFalse();
+        assertThat(cacheFilePath()).exists();
     }
 
     /**
@@ -264,11 +308,14 @@ public class ConfigFilePersistentHandlerTest {
      * 测试目的：验证密钥不匹配时不返回乱码。
      * 测试场景：缓存密文与 dataKey 由不同密钥产生。
      * 验证内容：返回 null。
+     *
+     * <p>错误密钥固定而非随机：AES-CBC 无完整性校验，随机错误密钥有约 1/256 概率恰好通过
+     * PKCS7 padding 校验从而解出乱码，会让本用例偶发失败。
      */
     @Test
     public void testLoadCacheFileWithMismatchedDataKey() throws IOException {
         // Arrange
-        writeCacheFile(cipherContent, Base64.getEncoder().encodeToString(AESUtil.generateAesKey()), "AES",
+        writeCacheFile(cipherContent, Base64.getEncoder().encodeToString(MISMATCHED_AES_KEY), "AES",
                 Boolean.TRUE);
 
         // Act & Assert
@@ -394,11 +441,19 @@ public class ConfigFilePersistentHandlerTest {
      */
     private void writeCacheFile(String content, String dataKey, String encryptAlgo, Boolean cacheEncrypted)
             throws IOException {
+        writeCacheFile(content, dataKey, encryptAlgo, cacheEncrypted, true);
+    }
+
+    /**
+     * 直接构造缓存文件，可指定 encrypted 字段，用于区分加密配置与普通配置的历史缓存。
+     */
+    private void writeCacheFile(String content, String dataKey, String encryptAlgo, Boolean cacheEncrypted,
+            boolean encrypted) throws IOException {
         StringBuilder yaml = new StringBuilder();
         yaml.append("content: \"").append(content).append("\"\n");
         yaml.append("md5: \"").append(MD5).append("\"\n");
         yaml.append("version: ").append(VERSION).append("\n");
-        yaml.append("encrypted: true\n");
+        yaml.append("encrypted: ").append(encrypted).append("\n");
         if (dataKey != null) {
             yaml.append("dataKey: \"").append(dataKey).append("\"\n");
         }

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandlerTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFilePersistentHandlerTest.java
@@ -1,0 +1,413 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.configuration.client.internal;
+
+import ch.qos.logback.classic.Level;
+import com.tencent.polaris.api.plugin.configuration.ConfigFile;
+import com.tencent.polaris.client.api.SDKContext;
+import com.tencent.polaris.configuration.client.LogCapture;
+import com.tencent.polaris.encrypt.util.AESUtil;
+import com.tencent.polaris.factory.config.ConfigurationImpl;
+import com.tencent.polaris.factory.config.configuration.ConfigFileConfigImpl;
+import com.tencent.polaris.factory.config.configuration.ConnectorConfigImpl;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link ConfigFilePersistentHandler}.
+ *
+ * @author evelynwei
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigFilePersistentHandlerTest {
+
+    private static final String NAMESPACE = "default";
+
+    private static final String FILE_GROUP = "biz-group";
+
+    private static final String FILE_NAME = "biz-config";
+
+    private static final String PLAIN_CONTENT = "jdbc.password=very-secret-value";
+
+    private static final long VERSION = 100L;
+
+    private static final String MD5 = "md5-of-source-content";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private SDKContext sdkContext;
+
+    private String persistDir;
+
+    private ConfigFilePersistentHandler handler;
+
+    private byte[] aesKey;
+
+    private String cipherContent;
+
+    @Before
+    public void setUp() throws IOException {
+        persistDir = temporaryFolder.newFolder("config-cache").getAbsolutePath();
+        ConfigurationImpl configuration = new ConfigurationImpl();
+        ConfigFileConfigImpl configFileConfig = new ConfigFileConfigImpl();
+        ConnectorConfigImpl connectorConfig = new ConnectorConfigImpl();
+        connectorConfig.setConnectorType("polaris");
+        connectorConfig.setPersistEnable(true);
+        connectorConfig.setPersistDir(persistDir);
+        connectorConfig.setPersistMaxWriteRetry(1);
+        connectorConfig.setPersistMaxReadRetry(0);
+        connectorConfig.setPersistRetryInterval(1L);
+        configFileConfig.setServerConnector(connectorConfig);
+        configuration.setConfigFile(configFileConfig);
+        when(sdkContext.getConfig()).thenReturn(configuration);
+        handler = new ConfigFilePersistentHandler(sdkContext);
+        // 模拟服务端加密行为：AES 密钥由服务端生成，正文用该密钥加密后下发
+        aesKey = AESUtil.generateAesKey();
+        cipherContent = AESUtil.encrypt(PLAIN_CONTENT, aesKey);
+    }
+
+    /**
+     * 测试目的：验证加密配置落盘为密文态。
+     * 测试场景：过滤器解密后的配置对象（content 明文、sourceContent 密文）写入缓存。
+     * 验证内容：缓存文件中 content 为密文、带 cacheEncrypted 标记与 dataKey，且不含明文正文。
+     */
+    @Test
+    public void testSaveEncryptedConfigFilePersistsCipherText() throws IOException {
+        // Arrange
+        ConfigFile configFile = assembleEncryptedConfigFile();
+
+        // Act
+        handler.saveConfigFile(configFile);
+
+        // Assert
+        String persisted = readPersistedText();
+        assertThat(persisted).doesNotContain(PLAIN_CONTENT);
+        assertThat(persisted).contains(cipherContent);
+        assertThat(persisted).contains("cacheEncrypted: true");
+        assertThat(persisted).contains(Base64.getEncoder().encodeToString(aesKey));
+    }
+
+    /**
+     * 测试目的：验证持久化副本与业务内存对象隔离。
+     * 测试场景：对正在被业务使用的明文对象执行落盘。
+     * 验证内容：落盘后源对象 content 仍为明文，cacheEncrypted 仍为 false。
+     */
+    @Test
+    public void testSaveEncryptedConfigFileNotModifySource() {
+        // Arrange
+        ConfigFile configFile = assembleEncryptedConfigFile();
+
+        // Act
+        handler.saveConfigFile(configFile);
+
+        // Assert
+        assertThat(configFile.getContent()).isEqualTo(PLAIN_CONTENT);
+        assertThat(configFile.getSourceContent()).isEqualTo(cipherContent);
+        assertThat(configFile.isCacheEncrypted()).isFalse();
+    }
+
+    /**
+     * 测试目的：验证进程重启后可从本地密文缓存恢复明文（本次改动的核心场景）。
+     * 测试场景：落盘后新建 handler 实例（不复用任何内存状态）读取缓存。
+     * 验证内容：content 解密为明文，sourceContent 保留密文，cacheEncrypted 被重置为 false，元数据不丢失。
+     */
+    @Test
+    public void testLoadEncryptedConfigFileAfterRestart() throws IOException {
+        // Arrange
+        handler.saveConfigFile(assembleEncryptedConfigFile());
+        ConfigFilePersistentHandler restartedHandler = new ConfigFilePersistentHandler(sdkContext);
+
+        // Act
+        ConfigFile loaded = restartedHandler.loadPersistedConfigFile(assembleConfigFileReq(), false);
+
+        // Assert
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getContent()).isEqualTo(PLAIN_CONTENT);
+        assertThat(loaded.getSourceContent()).isEqualTo(cipherContent);
+        assertThat(loaded.isCacheEncrypted()).isFalse();
+        assertThat(loaded.isEncrypted()).isTrue();
+        assertThat(loaded.getDataKey()).isEqualTo(Base64.getEncoder().encodeToString(aesKey));
+        assertThat(loaded.getEncryptAlgo()).isEqualTo("AES");
+        assertThat(loaded.getMd5()).isEqualTo(MD5);
+        assertThat(loaded.getVersion()).isEqualTo(VERSION);
+    }
+
+    /**
+     * 测试目的：验证未加密配置行为完全不变。
+     * 测试场景：sourceContent 为空的普通配置落盘后读回。
+     * 验证内容：缓存文件为明文、cacheEncrypted 为 false，读回内容一致。
+     */
+    @Test
+    public void testPlainConfigFileRoundTripUnchanged() throws IOException {
+        // Arrange
+        ConfigFile configFile = assembleConfigFileReq();
+        configFile.setContent(PLAIN_CONTENT);
+        configFile.setVersion(VERSION);
+        configFile.setMd5(MD5);
+
+        // Act
+        handler.saveConfigFile(configFile);
+        ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
+
+        // Assert
+        assertThat(readPersistedText()).contains(PLAIN_CONTENT);
+        assertThat(readPersistedText()).contains("cacheEncrypted: false");
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getContent()).isEqualTo(PLAIN_CONTENT);
+        assertThat(loaded.isCacheEncrypted()).isFalse();
+    }
+
+    /**
+     * 测试目的：验证不会产生「有密文无密钥」的不可解缓存。
+     * 测试场景：sourceContent 非空但 dataKey 缺失（解密链路异常）。
+     * 验证内容：走明文落盘分支，cacheEncrypted 为 false，读回仍是明文。
+     */
+    @Test
+    public void testSaveEncryptedConfigFileWithoutDataKeyFallsBackToPlain() throws IOException {
+        // Arrange
+        ConfigFile configFile = assembleEncryptedConfigFile();
+        configFile.setDataKey(null);
+
+        // Act
+        handler.saveConfigFile(configFile);
+        ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
+
+        // Assert
+        assertThat(readPersistedText()).contains("cacheEncrypted: false");
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getContent()).isEqualTo(PLAIN_CONTENT);
+    }
+
+    /**
+     * 测试目的：验证对历史明文缓存的向后兼容。
+     * 测试场景：旧版本写入的缓存文件无 cacheEncrypted 字段，content 为明文但 dataKey 存在。
+     * 验证内容：按明文原样返回，不触发解密。
+     */
+    @Test
+    public void testLoadLegacyPlainCacheFile() throws IOException {
+        // Arrange
+        writeCacheFile(PLAIN_CONTENT, Base64.getEncoder().encodeToString(aesKey), "AES", null);
+
+        // Act
+        ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
+
+        // Assert
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getContent()).isEqualTo(PLAIN_CONTENT);
+        assertThat(loaded.isCacheEncrypted()).isFalse();
+    }
+
+    /**
+     * 测试目的：验证密文缓存缺失密钥时不把密文当明文返回。
+     * 测试场景：缓存标记 cacheEncrypted=true 但 dataKey 缺失。
+     * 验证内容：返回 null，交由上层重试或降级。
+     */
+    @Test
+    public void testLoadCacheFileMissingDataKey() throws IOException {
+        // Arrange
+        writeCacheFile(cipherContent, null, "AES", Boolean.TRUE);
+
+        // Act
+        ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
+
+        // Assert
+        assertThat(loaded).isNull();
+    }
+
+    /**
+     * 测试目的：验证非法 Base64 密钥不会把异常抛给调用方。
+     * 测试场景：缓存 dataKey 为非法 Base64 串。
+     * 验证内容：返回 null 且不抛异常。
+     */
+    @Test
+    public void testLoadCacheFileWithInvalidDataKey() throws IOException {
+        // Arrange
+        writeCacheFile(cipherContent, "not-a-valid-base64-@@@", "AES", Boolean.TRUE);
+
+        // Act & Assert
+        assertThat(handler.loadPersistedConfigFile(assembleConfigFileReq(), false)).isNull();
+    }
+
+    /**
+     * 测试目的：验证密钥不匹配时不返回乱码。
+     * 测试场景：缓存密文与 dataKey 由不同密钥产生。
+     * 验证内容：返回 null。
+     */
+    @Test
+    public void testLoadCacheFileWithMismatchedDataKey() throws IOException {
+        // Arrange
+        writeCacheFile(cipherContent, Base64.getEncoder().encodeToString(AESUtil.generateAesKey()), "AES",
+                Boolean.TRUE);
+
+        // Act & Assert
+        assertThat(handler.loadPersistedConfigFile(assembleConfigFileReq(), false)).isNull();
+    }
+
+    /**
+     * 测试目的：验证未知加密算法快速失败。
+     * 测试场景：缓存 encryptAlgo 为本版本不支持的算法。
+     * 验证内容：返回 null，不尝试用 AES 解密。
+     */
+    @Test
+    public void testLoadCacheFileWithUnsupportedAlgo() throws IOException {
+        // Arrange
+        writeCacheFile(cipherContent, Base64.getEncoder().encodeToString(aesKey), "SM4", Boolean.TRUE);
+
+        // Act & Assert
+        assertThat(handler.loadPersistedConfigFile(assembleConfigFileReq(), false)).isNull();
+    }
+
+    /**
+     * 测试目的：验证缺失 encryptAlgo 的密文缓存按 AES 兼容处理。
+     * 测试场景：缓存标记 cacheEncrypted=true 但无 encryptAlgo 字段。
+     * 验证内容：仍能正常解密出明文。
+     */
+    @Test
+    public void testLoadCacheFileWithoutAlgoUsesAes() throws IOException {
+        // Arrange
+        writeCacheFile(cipherContent, Base64.getEncoder().encodeToString(aesKey), null, Boolean.TRUE);
+
+        // Act
+        ConfigFile loaded = handler.loadPersistedConfigFile(assembleConfigFileReq(), false);
+
+        // Assert
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getContent()).isEqualTo(PLAIN_CONTENT);
+    }
+
+    /**
+     * 测试目的：验证落盘成功路径的日志不泄露正文与密钥。
+     * 测试场景：加密配置落盘成功，捕获 start / end 两条 INFO 日志。
+     * 验证内容：日志含文件坐标便于定位，但不含明文、密文与 dataKey。
+     */
+    @Test
+    public void testSaveConfigFileSuccessLogsWithoutSecrets() {
+        // Arrange
+        ConfigFile configFile = assembleEncryptedConfigFile();
+
+        // Act
+        try (LogCapture capture = LogCapture.attach(ConfigFilePersistentHandler.class, Level.INFO)) {
+            handler.saveConfigFile(configFile);
+
+            // Assert
+            String logs = capture.text();
+            assertThat(logs).contains("start to save config file");
+            assertThat(logs).contains("end to save config file");
+            assertThat(logs).contains(FILE_NAME);
+            assertThat(logs).doesNotContain(PLAIN_CONTENT);
+            assertThat(logs).doesNotContain(cipherContent);
+            assertThat(logs).doesNotContain(configFile.getDataKey());
+        }
+    }
+
+    /**
+     * 测试目的：验证落盘失败路径（含重试超限）的日志不泄露正文与密钥。
+     * 测试场景：把锁文件路径预先占为目录，使加锁必然抛 IOException 触发重试与最终 error。
+     * 验证内容：输出重试失败信息，且不含明文、密文与 dataKey。
+     */
+    @Test
+    public void testSaveConfigFileFailureLogsWithoutSecrets() throws IOException {
+        // Arrange：锁文件位置被目录占用，RandomAccessFile 打开必然失败
+        Files.createDirectory(Paths.get(persistDir, cacheFileName() + ".lock"));
+        ConfigFile configFile = assembleEncryptedConfigFile();
+
+        // Act
+        try (LogCapture capture = LogCapture.attach(ConfigFilePersistentHandler.class, Level.INFO)) {
+            handler.saveConfigFile(configFile);
+
+            // Assert
+            String logs = capture.text();
+            assertThat(logs).contains("fail to persist config file");
+            assertThat(logs).doesNotContain(PLAIN_CONTENT);
+            assertThat(logs).doesNotContain(cipherContent);
+            assertThat(logs).doesNotContain(configFile.getDataKey());
+        }
+    }
+
+    private ConfigFile assembleConfigFileReq() {
+        return new ConfigFile(NAMESPACE, FILE_GROUP, FILE_NAME);
+    }
+
+    /**
+     * 构造过滤器解密后的内存态对象：content 为明文，sourceContent 为服务端密文，
+     * dataKey 为 Base64 编码的明文 AES 密钥。
+     */
+    private ConfigFile assembleEncryptedConfigFile() {
+        ConfigFile configFile = assembleConfigFileReq();
+        configFile.setContent(PLAIN_CONTENT);
+        configFile.setSourceContent(cipherContent);
+        configFile.setVersion(VERSION);
+        configFile.setMd5(MD5);
+        configFile.setName("v1.0.0");
+        configFile.setEncrypted(true);
+        configFile.setEncryptAlgo("AES");
+        configFile.setDataKey(Base64.getEncoder().encodeToString(aesKey));
+        return configFile;
+    }
+
+    private String cacheFileName() {
+        return String.format("%s#%s#%s.yaml", NAMESPACE, FILE_GROUP, FILE_NAME);
+    }
+
+    private Path cacheFilePath() {
+        return Paths.get(persistDir, cacheFileName());
+    }
+
+    private String readPersistedText() throws IOException {
+        return new String(Files.readAllBytes(cacheFilePath()), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * 直接构造缓存文件，用于覆盖历史格式与损坏格式等无法由本版本写出的场景。
+     */
+    private void writeCacheFile(String content, String dataKey, String encryptAlgo, Boolean cacheEncrypted)
+            throws IOException {
+        StringBuilder yaml = new StringBuilder();
+        yaml.append("content: \"").append(content).append("\"\n");
+        yaml.append("md5: \"").append(MD5).append("\"\n");
+        yaml.append("version: ").append(VERSION).append("\n");
+        yaml.append("encrypted: true\n");
+        if (dataKey != null) {
+            yaml.append("dataKey: \"").append(dataKey).append("\"\n");
+        }
+        if (encryptAlgo != null) {
+            yaml.append("encryptAlgo: \"").append(encryptAlgo).append("\"\n");
+        }
+        if (cacheEncrypted != null) {
+            yaml.append("cacheEncrypted: ").append(cacheEncrypted).append("\n");
+        }
+        Files.write(cacheFilePath(), yaml.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshotTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/ConfigFileSnapshotTest.java
@@ -87,4 +87,43 @@ public class ConfigFileSnapshotTest {
         assertThat(snapshot.getEncryptAlgo()).isEqualTo("AES");
         assertThat(snapshot.getDataKey()).isEqualTo("key");
     }
+
+    /**
+     * 测试目的：全量构造器可同时携带版本名与加密字段。
+     * 测试场景：直接使用全量构造器。
+     * 验证内容：八个字段逐一回读一致，版本名不会被加密字段挤掉。
+     */
+    @Test
+    public void testFullSnapshotConstructor() {
+        ConfigFileSnapshot snapshot = new ConfigFileSnapshot(7, "v2.0.0", "md5full", "cipher", 456L,
+                true, "AES", "key");
+
+        assertThat(snapshot.getVersion()).isEqualTo(7);
+        assertThat(snapshot.getVersionName()).isEqualTo("v2.0.0");
+        assertThat(snapshot.getMd5()).isEqualTo("md5full");
+        assertThat(snapshot.getContent()).isEqualTo("cipher");
+        assertThat(snapshot.getEffectiveTime()).isEqualTo(456L);
+        assertThat(snapshot.isEncrypted()).isTrue();
+        assertThat(snapshot.getEncryptAlgo()).isEqualTo("AES");
+        assertThat(snapshot.getDataKey()).isEqualTo("key");
+    }
+
+    /**
+     * 测试目的：加密重载不携带版本名，普通重载不携带加密字段，各自默认值明确。
+     * 测试场景：分别使用加密七参重载与普通五参重载。
+     * 验证内容：加密快照版本名为 null，普通快照加密字段为默认值。
+     */
+    @Test
+    public void testOverloadDefaults() {
+        ConfigFileSnapshot encryptedSnapshot = new ConfigFileSnapshot(3, "md5abc", "cipher", 1L,
+                true, "AES", "key");
+        ConfigFileSnapshot plainSnapshot = new ConfigFileSnapshot(3, "md5abc", "k=v", 1L, "v1.0.0");
+
+        assertThat(encryptedSnapshot.getVersionName()).isNull();
+        assertThat(encryptedSnapshot.isEncrypted()).isTrue();
+        assertThat(plainSnapshot.getVersionName()).isEqualTo("v1.0.0");
+        assertThat(plainSnapshot.isEncrypted()).isFalse();
+        assertThat(plainSnapshot.getEncryptAlgo()).isNull();
+        assertThat(plainSnapshot.getDataKey()).isNull();
+    }
 }

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
@@ -218,6 +218,54 @@ public class RemoteConfigFileRepoTest {
     }
 
     /**
+     * 测试目的：内存为空且本地缓存命中时，第一次远端失败立即回落，不再走 1/2/4 秒退避。
+     * 测试场景：过滤链抛超时，持久化层返回缓存。
+     * 验证内容：只拉一次远端，业务内容来自缓存。
+     */
+    @Test
+    public void testFallbackToLocalCacheOnFirstFailure() {
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        ConfigFile cachedConfigFile = new ConfigFile(ConfigFileTestUtils.testNamespace,
+                ConfigFileTestUtils.testGroup, ConfigFileTestUtils.testFileName);
+        cachedConfigFile.setContent("cached-plain");
+        cachedConfigFile.setVersion(12);
+        when(configFileFilterChain.execute(any(), any())).thenThrow(new RetriableException(ErrorCode.API_TIMEOUT, ""));
+        when(configFilePersistHandler.loadPersistedConfigFile(any(), anyBoolean())).thenReturn(cachedConfigFile);
+
+        long startedAt = System.currentTimeMillis();
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+        long elapsedMs = System.currentTimeMillis() - startedAt;
+
+        verify(configFileFilterChain, times(1)).execute(any(), any());
+        verify(configFilePersistHandler).loadPersistedConfigFile(any(), anyBoolean());
+        assertThat(remoteConfigFileRepo.getContent()).isEqualTo("cached-plain");
+        assertThat(remoteConfigFileRepo.getConfigFileVersion()).isEqualTo(12);
+        assertThat(elapsedMs).as("must not wait exponential backoff 1+2+4s").isLessThan(2000);
+    }
+
+    /**
+     * 测试目的：无本地缓存时仍耗尽三次远端重试。
+     * 测试场景：过滤链持续失败，持久化层返回 null。
+     * 验证内容：过滤链执行三次。
+     */
+    @Test
+    public void testPullRetriesWhenLocalCacheMissing() {
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        when(configFileFilterChain.execute(any(), any())).thenThrow(new RetriableException(ErrorCode.API_TIMEOUT, ""));
+        when(configFilePersistHandler.loadPersistedConfigFile(any(), anyBoolean())).thenReturn(null);
+
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+
+        verify(configFileFilterChain, times(3)).execute(any(), any());
+        verify(configFilePersistHandler, times(2)).loadPersistedConfigFile(any(), anyBoolean());
+        Assert.assertNull(remoteConfigFileRepo.getContent());
+    }
+
+    /**
      * 测试目的：验证降级读本地缓存的日志不泄露正文与密钥。
      * 测试场景：远端拉取失败触发 fallback，缓存命中一个加密配置（正文为敏感串）。
      * 验证内容：成功日志只含坐标与版本，不含明文、密文与 dataKey。

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
@@ -106,6 +106,57 @@ public class RemoteConfigFileRepoTest {
         assertThat(snapshot.getVersion()).isEqualTo(version);
         assertThat(snapshot.getVersionName()).isEqualTo("v1.0.0");
         assertThat(snapshot.getMd5()).isEqualTo("md5abc");
+        assertThat(remoteConfigFileRepo.isEncrypted()).isFalse();
+    }
+
+    /**
+     * 测试目的：加密标记从服务端响应对象透出到 repo，供上层框架在首次加载时判断敏感性。
+     * 测试场景：服务端返回 encrypted=true 的配置文件。
+     * 验证内容：repo.isEncrypted() 为 true，且与快照的加密标记一致。
+     */
+    @Test
+    public void testIsEncryptedReflectsServerResponse() {
+        // Arrange
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        ConfigFile configFile = new ConfigFile(ConfigFileTestUtils.testNamespace, ConfigFileTestUtils.testGroup,
+                ConfigFileTestUtils.testFileName);
+        configFile.setContent("jdbc.password=secret");
+        configFile.setVersion(100);
+        configFile.setMd5("md5abc");
+        configFile.setEncrypted(true);
+        configFile.setEncryptAlgo("AES");
+        when(configFileFilterChain.execute(any(), any()))
+                .thenReturn(new ConfigFileResponse(ServerCodes.EXECUTE_SUCCESS, "", configFile));
+
+        // Act
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+
+        // Assert
+        assertThat(remoteConfigFileRepo.isEncrypted()).isTrue();
+        assertThat(remoteConfigFileRepo.getSnapshot().isEncrypted()).isTrue();
+    }
+
+    /**
+     * 测试目的：未拉到配置时加密标记不应误报为 true。
+     * 测试场景：服务端返回 NOT_FOUND，内存中无配置对象。
+     * 验证内容：isEncrypted() 为 false，不抛 NPE。
+     */
+    @Test
+    public void testIsEncryptedFalseWhenNoConfigPulled() {
+        // Arrange
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        when(configFileFilterChain.execute(any(), any()))
+                .thenReturn(new ConfigFileResponse(ServerCodes.NOT_FOUND_RESOURCE, "", null));
+
+        // Act
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+
+        // Assert
+        assertThat(remoteConfigFileRepo.isEncrypted()).isFalse();
     }
 
     /**
@@ -243,6 +294,68 @@ public class RemoteConfigFileRepoTest {
         assertThat(remoteConfigFileRepo.getContent()).isEqualTo("cached-plain");
         assertThat(remoteConfigFileRepo.getConfigFileVersion()).isEqualTo(12);
         assertThat(elapsedMs).as("must not wait exponential backoff 1+2+4s").isLessThan(2000);
+    }
+
+    /**
+     * 测试目的：降级本地缓存后后台补拉一次，远端恢复即收敛，不必等长轮询。
+     * 测试场景：首次拉取抛超时命中缓存，随后远端恢复返回更高版本。
+     * 验证内容：构造完成时用缓存内容，补拉执行后内容与版本更新为远端值。
+     */
+    @Test
+    public void testCatchUpPullConvergesAfterFallback() throws InterruptedException {
+        // Arrange
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        ConfigFile cachedConfigFile = new ConfigFile(ConfigFileTestUtils.testNamespace,
+                ConfigFileTestUtils.testGroup, ConfigFileTestUtils.testFileName);
+        cachedConfigFile.setContent("cached-plain");
+        cachedConfigFile.setVersion(12);
+        ConfigFile freshConfigFile = new ConfigFile(ConfigFileTestUtils.testNamespace,
+                ConfigFileTestUtils.testGroup, ConfigFileTestUtils.testFileName);
+        freshConfigFile.setContent("remote-fresh");
+        freshConfigFile.setVersion(13);
+        when(configFileFilterChain.execute(any(), any()))
+                .thenThrow(new RetriableException(ErrorCode.API_TIMEOUT, ""))
+                .thenReturn(new ConfigFileResponse(ServerCodes.EXECUTE_SUCCESS, "", freshConfigFile));
+        when(configFilePersistHandler.loadPersistedConfigFile(any(), anyBoolean())).thenReturn(cachedConfigFile);
+
+        // Act
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+
+        // Assert
+        assertThat(remoteConfigFileRepo.getContent()).isEqualTo("cached-plain");
+        TimeUnit.SECONDS.sleep(6);
+        assertThat(remoteConfigFileRepo.getContent()).isEqualTo("remote-fresh");
+        assertThat(remoteConfigFileRepo.getConfigFileVersion()).isEqualTo(13);
+    }
+
+    /**
+     * 测试目的：补拉只试一次，且失败后不重复加载已在内存中的缓存。
+     * 测试场景：远端持续失败，首次拉取降级命中缓存。
+     * 验证内容：远端共两次调用（首拉 + 补拉），持久化层只读一次，内存配置保持不变。
+     */
+    @Test
+    public void testCatchUpPullTriesOnceAndKeepsMemoryConfig() throws InterruptedException {
+        // Arrange
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        ConfigFile cachedConfigFile = new ConfigFile(ConfigFileTestUtils.testNamespace,
+                ConfigFileTestUtils.testGroup, ConfigFileTestUtils.testFileName);
+        cachedConfigFile.setContent("cached-plain");
+        cachedConfigFile.setVersion(12);
+        when(configFileFilterChain.execute(any(), any())).thenThrow(new RetriableException(ErrorCode.API_TIMEOUT, ""));
+        when(configFilePersistHandler.loadPersistedConfigFile(any(), anyBoolean())).thenReturn(cachedConfigFile);
+
+        // Act
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+        TimeUnit.SECONDS.sleep(6);
+
+        // Assert
+        verify(configFileFilterChain, times(2)).execute(any(), any());
+        verify(configFilePersistHandler, times(1)).loadPersistedConfigFile(any(), anyBoolean());
+        assertThat(remoteConfigFileRepo.getContent()).isEqualTo("cached-plain");
     }
 
     /**

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/internal/RemoteConfigFileRepoTest.java
@@ -17,6 +17,7 @@
 
 package com.tencent.polaris.configuration.client.internal;
 
+import ch.qos.logback.classic.Level;
 import com.tencent.polaris.api.exception.ErrorCode;
 import com.tencent.polaris.api.exception.RetriableException;
 import com.tencent.polaris.api.exception.ServerCodes;
@@ -27,6 +28,7 @@ import com.tencent.polaris.api.plugin.filter.ConfigFileFilterChain;
 import com.tencent.polaris.client.api.SDKContext;
 import com.tencent.polaris.configuration.api.core.ConfigFileMetadata;
 import com.tencent.polaris.configuration.client.ConfigFileTestUtils;
+import com.tencent.polaris.configuration.client.LogCapture;
 import com.tencent.polaris.factory.config.ConfigurationImpl;
 import com.tencent.polaris.factory.config.configuration.ConfigFileConfigImpl;
 import com.tencent.polaris.factory.config.configuration.ConnectorConfigImpl;
@@ -37,8 +39,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -211,6 +215,138 @@ public class RemoteConfigFileRepoTest {
 
         Assert.assertNull(remoteConfigFileRepo.getContent());
         Assert.assertEquals(0, remoteConfigFileRepo.getConfigFileVersion());
+    }
+
+    /**
+     * 测试目的：验证降级读本地缓存的日志不泄露正文与密钥。
+     * 测试场景：远端拉取失败触发 fallback，缓存命中一个加密配置（正文为敏感串）。
+     * 验证内容：成功日志只含坐标与版本，不含明文、密文与 dataKey。
+     */
+    @Test
+    public void testLoadLocalCacheLogsWithoutSecrets() {
+        // Arrange
+        String sensitiveContent = "jdbc.password=cache-secret-value";
+        String dataKey = "UDEyMzQ1Njc4OTAxMjM0NQ==";
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        ConfigFile cachedConfigFile = new ConfigFile(ConfigFileTestUtils.testNamespace,
+                ConfigFileTestUtils.testGroup, ConfigFileTestUtils.testFileName);
+        cachedConfigFile.setContent(sensitiveContent);
+        cachedConfigFile.setSourceContent("cache-cipher-text");
+        cachedConfigFile.setVersion(100);
+        cachedConfigFile.setMd5("md5abc");
+        cachedConfigFile.setEncrypted(true);
+        cachedConfigFile.setDataKey(dataKey);
+        when(configFileFilterChain.execute(any(), any())).thenReturn(new ConfigFileResponse(50000, "", null));
+        when(configFilePersistHandler.loadPersistedConfigFile(any(), anyBoolean())).thenReturn(cachedConfigFile);
+
+        // Act
+        try (LogCapture capture = LogCapture.attach(AbstractConfigFileRepo.class, Level.INFO)) {
+            new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                    configFileConnector, configFileMetadata, configFilePersistHandler);
+
+            // Assert
+            String logs = capture.text();
+            assertThat(logs).contains("load local cache success");
+            assertThat(logs).contains(ConfigFileTestUtils.testFileName);
+            assertThat(logs).contains("encrypted=true");
+            assertThat(logs).doesNotContain(sensitiveContent);
+            assertThat(logs).doesNotContain("cache-cipher-text");
+            assertThat(logs).doesNotContain(dataKey);
+        }
+    }
+
+    /**
+     * 测试目的：验证缓存未命中时的失败日志同样只含坐标。
+     * 测试场景：远端拉取失败且本地缓存返回 null。
+     * 验证内容：输出 load local cache fail 与文件坐标，不含任何正文字段。
+     */
+    @Test
+    public void testLoadLocalCacheFailLogsOnlyMetadata() {
+        // Arrange
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        when(configFileFilterChain.execute(any(), any())).thenReturn(new ConfigFileResponse(50000, "", null));
+        when(configFilePersistHandler.loadPersistedConfigFile(any(), anyBoolean())).thenReturn(null);
+
+        // Act
+        try (LogCapture capture = LogCapture.attach(AbstractConfigFileRepo.class, Level.INFO)) {
+            new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                    configFileConnector, configFileMetadata, configFilePersistHandler);
+
+            // Assert
+            String logs = capture.text();
+            assertThat(logs).contains("load local cache fail");
+            assertThat(logs).contains(ConfigFileTestUtils.testFileName);
+            assertThat(logs).doesNotContain("content=");
+            assertThat(logs).doesNotContain("dataKey");
+        }
+    }
+
+    /**
+     * 测试目的：验证内存业务对象恒为明文态，不会继承缓存密文标记。
+     * 测试场景：过滤链返回的对象被误置 cacheEncrypted=true。
+     * 验证内容：deepCloneConfigFile 产生的内存对象 cacheEncrypted 仍为 false。
+     */
+    @Test
+    public void testDeepCloneNotCopyCacheEncrypted() throws Exception {
+        // Arrange
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        ConfigFile configFile = new ConfigFile(ConfigFileTestUtils.testNamespace, ConfigFileTestUtils.testGroup,
+                ConfigFileTestUtils.testFileName);
+        configFile.setContent("hello world");
+        configFile.setVersion(100);
+        configFile.setMd5("md5abc");
+        configFile.setCacheEncrypted(true);
+        when(configFileFilterChain.execute(any(), any()))
+                .thenReturn(new ConfigFileResponse(ServerCodes.EXECUTE_SUCCESS, "", configFile));
+
+        // Act
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+
+        // Assert
+        Field field = RemoteConfigFileRepo.class.getDeclaredField("remoteConfigFile");
+        field.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        AtomicReference<ConfigFile> holder = (AtomicReference<ConfigFile>) field.get(remoteConfigFileRepo);
+        assertThat(holder.get()).isNotNull();
+        assertThat(holder.get().isCacheEncrypted()).isFalse();
+        assertThat(holder.get().getContent()).isEqualTo("hello world");
+    }
+
+    /**
+     * 测试目的：验证从本地密文缓存降级恢复后，加密语义与 ACK 链路仍然正确。
+     * 测试场景：远端拉取失败降级读本地缓存，缓存已由持久化层解密（content 明文、sourceContent 密文）。
+     * 验证内容：业务读到明文，而快照回传的是密文与密钥，不泄露明文。
+     */
+    @Test
+    public void testFallbackToEncryptedLocalCache() {
+        // Arrange
+        ConfigFileMetadata configFileMetadata = ConfigFileTestUtils.assembleDefaultConfigFileMeta();
+        ConfigFile cachedConfigFile = new ConfigFile(ConfigFileTestUtils.testNamespace,
+                ConfigFileTestUtils.testGroup, ConfigFileTestUtils.testFileName);
+        cachedConfigFile.setContent("plain-text");
+        cachedConfigFile.setSourceContent("cipher-text");
+        cachedConfigFile.setVersion(100);
+        cachedConfigFile.setMd5("md5abc");
+        cachedConfigFile.setEncrypted(true);
+        cachedConfigFile.setEncryptAlgo("AES");
+        cachedConfigFile.setDataKey("UDEyMzQ1Njc4OTAxMjM0NQ==");
+        when(configFileFilterChain.execute(any(), any())).thenReturn(new ConfigFileResponse(50000, "", null));
+        when(configFilePersistHandler.loadPersistedConfigFile(any(), anyBoolean())).thenReturn(cachedConfigFile);
+
+        // Act
+        RemoteConfigFileRepo remoteConfigFileRepo =
+                new RemoteConfigFileRepo(sdkContext, configFileLongPollingService, configFileFilterChain,
+                        configFileConnector, configFileMetadata, configFilePersistHandler);
+
+        // Assert
+        assertThat(remoteConfigFileRepo.getContent()).isEqualTo("plain-text");
+        ConfigFileSnapshot snapshot = remoteConfigFileRepo.getSnapshot();
+        assertThat(snapshot.getContent()).isEqualTo("cipher-text");
+        assertThat(snapshot.getMd5()).isEqualTo("md5abc");
+        assertThat(snapshot.isEncrypted()).isTrue();
+        assertThat(snapshot.getDataKey()).isEqualTo("UDEyMzQ1Njc4OTAxMjM0NQ==");
     }
 
     @Test

--- a/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/util/YamlParserTest.java
+++ b/polaris-configuration/polaris-configuration-client/src/test/java/com/tencent/polaris/configuration/client/util/YamlParserTest.java
@@ -1,0 +1,83 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.configuration.client.util;
+
+import ch.qos.logback.classic.Level;
+import com.tencent.polaris.configuration.client.LogCapture;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link YamlParser}.
+ *
+ * @author evelynwei
+ */
+public class YamlParserTest {
+
+    private static final String SECRET_VALUE = "very-secret-value";
+
+    private static final String YAML_CONTENT = "jdbc:\n  password: " + SECRET_VALUE + "\n";
+
+    /**
+     * 测试目的：验证 DEBUG 级别下解析日志不泄露配置正文。
+     * 测试场景：解析含敏感值的 YAML，日志级别开到 DEBUG。
+     * 验证内容：日志不含敏感值，但保留长度信息以便排障；解析结果本身仍为明文。
+     */
+    @Test
+    public void testProcessDebugLogWithoutContent() {
+        // Arrange
+        YamlParser parser = new YamlParser();
+
+        // Act
+        try (LogCapture capture = LogCapture.attach(YamlParser.class, Level.DEBUG)) {
+            Properties properties = parser.yamlToProperties(YAML_CONTENT);
+
+            // Assert
+            assertThat(properties.getProperty("jdbc.password")).isEqualTo(SECRET_VALUE);
+            String logs = capture.text();
+            assertThat(logs).doesNotContain(SECRET_VALUE);
+            assertThat(logs).contains("length = " + YAML_CONTENT.length());
+            assertThat(logs).contains("loaded 1 document(s)");
+            // key 集合保留：排障需要知道解析出哪些配置项，key 本身不敏感
+            assertThat(logs).contains("jdbc.password");
+        }
+    }
+
+    /**
+     * 测试目的：验证空内容解析不因日志改动抛 NPE。
+     * 测试场景：传入 null 与空串。
+     * 验证内容：返回空 Properties，日志输出 length = 0。
+     */
+    @Test
+    public void testProcessEmptyContent() {
+        // Arrange
+        YamlParser parser = new YamlParser();
+
+        // Act
+        try (LogCapture capture = LogCapture.attach(YamlParser.class, Level.DEBUG)) {
+            Properties properties = parser.yamlToProperties("");
+
+            // Assert
+            assertThat(properties).isEmpty();
+            assertThat(capture.text()).contains("length = 0");
+        }
+    }
+}

--- a/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/configuration/ConfigFile.java
+++ b/polaris-plugins/polaris-plugin-api/src/main/java/com/tencent/polaris/api/plugin/configuration/ConfigFile.java
@@ -47,6 +47,17 @@ public class ConfigFile extends BaseEntity {
     private String dataKey;
     private String encryptAlgo;
     private boolean encrypted = Boolean.FALSE;
+    /**
+     * 标记本对象的 content 是否为「本地缓存密文态」。
+     *
+     * <p>仅在本地缓存读写链路中有意义：写入时由持久化副本置为 true（表示 content 已是密文，
+     * dataKey 为其 Base64 AES 密钥）；读取时依据该标记决定是否解密。
+     * 内存中的业务对象该字段恒为 false。历史缓存文件无此字段，反序列化后为 false，按明文处理。
+     *
+     * <p>与 encrypted 的区别：encrypted 表示该配置在服务端是否为加密配置（业务语义，来自服务端）；
+     * cacheEncrypted 表示本地缓存文件里的 content 当前是否为密文（存储语义，本地生成）。
+     */
+    private boolean cacheEncrypted = Boolean.FALSE;
     private Date releaseTime;
 
     public ConfigFile(String namespace, String fileGroup, String fileName) {
@@ -134,6 +145,14 @@ public class ConfigFile extends BaseEntity {
         this.encrypted = encrypted;
     }
 
+    public boolean isCacheEncrypted() {
+        return cacheEncrypted;
+    }
+
+    public void setCacheEncrypted(boolean cacheEncrypted) {
+        this.cacheEncrypted = cacheEncrypted;
+    }
+
     public String getDataKey() {
         return dataKey;
     }
@@ -181,16 +200,22 @@ public class ConfigFile extends BaseEntity {
         return Objects.hash(namespace, fileGroup, fileName, content, version, md5, releaseTime);
     }
 
+    /**
+     * 不输出 content 与 sourceContent：加密配置的正文不得进入日志文件。
+     * md5 为源内容摘要，不可逆，保留以便问题定位。
+     *
+     * @return 仅含元数据的字符串
+     */
     @Override
     public String toString() {
         return "ConfigFile{" +
                "namespace='" + namespace + '\'' +
                ", fileGroup='" + fileGroup + '\'' +
                ", fileName='" + fileName + '\'' +
-               ", content='" + content + '\'' +
                ", version=" + version +
                 ", name=" + name +
                ", md5='" + md5 + '\'' +
+               ", encrypted=" + encrypted +
                ", releaseTime=" + releaseTime + '\'' +
                '}';
     }

--- a/polaris-plugins/polaris-plugin-api/src/test/java/com/tencent/polaris/api/plugin/configuration/ConfigFileTest.java
+++ b/polaris-plugins/polaris-plugin-api/src/test/java/com/tencent/polaris/api/plugin/configuration/ConfigFileTest.java
@@ -1,0 +1,125 @@
+/*
+ * Tencent is pleased to support the open source community by making polaris-java available.
+ *
+ * Copyright (C) 2021 Tencent. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.tencent.polaris.api.plugin.configuration;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for {@link ConfigFile}.
+ *
+ * @author evelynwei
+ */
+public class ConfigFileTest {
+
+    private static final String NAMESPACE = "default";
+
+    private static final String FILE_GROUP = "biz-group";
+
+    private static final String FILE_NAME = "biz-config";
+
+    private static final String PLAIN_CONTENT = "jdbc.password=very-secret-value";
+
+    private static final String CIPHER_CONTENT = "5Lit5paH5a+G5paH";
+
+    /**
+     * 测试目的：验证缓存格式标记的默认值与读写。
+     * 测试场景：新建对象后读取默认值，再设置为 true。
+     * 验证内容：默认为 false，设置后为 true。
+     */
+    @Test
+    public void testCacheEncryptedDefaultFalse() {
+        // Arrange & Act
+        ConfigFile configFile = assembleConfigFile();
+
+        // Assert
+        assertThat(configFile.isCacheEncrypted()).isFalse();
+        configFile.setCacheEncrypted(true);
+        assertThat(configFile.isCacheEncrypted()).isTrue();
+    }
+
+    /**
+     * 测试目的：验证 toString 不再泄露配置正文。
+     * 测试场景：对象同时持有明文 content 与密文 sourceContent。
+     * 验证内容：输出不含两者的值。
+     */
+    @Test
+    public void testToStringWithoutContent() {
+        // Arrange
+        ConfigFile configFile = assembleConfigFile();
+
+        // Act
+        String str = configFile.toString();
+
+        // Assert
+        assertThat(str).doesNotContain(PLAIN_CONTENT);
+        assertThat(str).doesNotContain(CIPHER_CONTENT);
+    }
+
+    /**
+     * 测试目的：验证 toString 的问题定位能力不退化。
+     * 测试场景：对象已设置完整元数据。
+     * 验证内容：输出包含坐标、版本、md5 与加密标记。
+     */
+    @Test
+    public void testToStringKeepsMetadata() {
+        // Arrange
+        ConfigFile configFile = assembleConfigFile();
+
+        // Act
+        String str = configFile.toString();
+
+        // Assert
+        assertThat(str).contains(NAMESPACE);
+        assertThat(str).contains(FILE_GROUP);
+        assertThat(str).contains(FILE_NAME);
+        assertThat(str).contains("version=100");
+        assertThat(str).contains("md5-of-source-content");
+        assertThat(str).contains("encrypted=true");
+    }
+
+    /**
+     * 测试目的：验证 cacheEncrypted 不参与业务身份判定。
+     * 测试场景：两个内容一致的对象，仅 cacheEncrypted 不同。
+     * 验证内容：equals 与 hashCode 均不受影响。
+     */
+    @Test
+    public void testEqualsIgnoresCacheEncrypted() {
+        // Arrange
+        ConfigFile one = assembleConfigFile();
+        ConfigFile another = assembleConfigFile();
+        another.setCacheEncrypted(true);
+
+        // Act & Assert
+        assertThat(one).isEqualTo(another);
+        assertThat(one.hashCode()).isEqualTo(another.hashCode());
+    }
+
+    private ConfigFile assembleConfigFile() {
+        ConfigFile configFile = new ConfigFile(NAMESPACE, FILE_GROUP, FILE_NAME);
+        configFile.setContent(PLAIN_CONTENT);
+        configFile.setSourceContent(CIPHER_CONTENT);
+        configFile.setVersion(100L);
+        configFile.setName("v1.0.0");
+        configFile.setMd5("md5-of-source-content");
+        configFile.setEncrypted(true);
+        configFile.setEncryptAlgo("AES");
+        return configFile;
+    }
+}

--- a/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/src/main/java/com/tencent/polaris/plugins/configfilefilter/crypto/AESCrypto.java
+++ b/polaris-plugins/polaris-plugins-configfilefilter/configfilefilter-crypto/src/main/java/com/tencent/polaris/plugins/configfilefilter/crypto/AESCrypto.java
@@ -25,6 +25,7 @@ import com.tencent.polaris.api.plugin.common.PluginTypes;
 import com.tencent.polaris.api.plugin.compose.Extensions;
 import com.tencent.polaris.api.plugin.configuration.ConfigFile;
 import com.tencent.polaris.api.plugin.filter.Crypto;
+import com.tencent.polaris.encrypt.EncryptConstants;
 import com.tencent.polaris.encrypt.util.AESUtil;
 
 /**
@@ -49,7 +50,7 @@ public class AESCrypto implements Crypto {
 
     @Override
     public String getName() {
-        return "AES";
+        return EncryptConstants.ALGO_AES;
     }
 
     @Override

--- a/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/main/java/com/tencent/polaris/plugins/connector/grpc/ClientEventStream.java
+++ b/polaris-plugins/polaris-plugins-connector/connector-polaris-grpc/src/main/java/com/tencent/polaris/plugins/connector/grpc/ClientEventStream.java
@@ -163,9 +163,14 @@ public class ClientEventStream implements StreamObserver<ClientEvent>, AutoClose
         }
     }
 
+    private static int contentLength(String content) {
+        return content == null ? 0 : content.length();
+    }
+
     private void handlePush(ClientEvent event) {
-        LOG.info("[ClientEvent] received push, index = {}, clientId = {}, content = {}",
-                event.getIndex(), clientId, event.getContent());
+        // 不输出全文：ACK/PUSH 内容可能携带配置正文与属性值
+        LOG.info("[ClientEvent] received push, index = {}, clientId = {}, contentLength = {}",
+                event.getIndex(), clientId, contentLength(event.getContent()));
         String ackContent = INTERNAL_ERROR_ACK;
         try {
             String handlerAck = handler.onPush(event.getIndex(), event.getContent());
@@ -191,8 +196,8 @@ public class ClientEventStream implements StreamObserver<ClientEvent>, AutoClose
             return;
         }
         try {
-            LOG.info("[ClientEvent] send ack, index = {}, clientId = {}, content = {}",
-                    index, clientId, ackContent);
+            LOG.info("[ClientEvent] send ack, index = {}, clientId = {}, contentLength = {}",
+                    index, clientId, contentLength(ackContent));
             synchronized (clientLock) {
                 observer.onNext(ClientEvent.newBuilder()
                         .setType(ClientEvent.ClientEventType.ACK)


### PR DESCRIPTION
# PR: feat: persist encrypted config as ciphertext and redact logs

> 目标分支：`main` ← `feat/sensitive-data-encryption`
> 上游仓库：`polarismesh/polaris-java`
> 关联：配置加密场景的缓存密文化与日志脱敏；配置生效查询前置 #721、#722
> 当前 HEAD：`49216547`（已与 `origin/feat/sensitive-data-encryption` 同步）

本需求相关提交（新 → 旧）：

| hash | message |
|------|---------|
| `49216547` | fix: keep conflict file_value in plaintext ACK |
| `ca08cf90` | fix: keep external effective values when attributing ACK sources |
| `6b0ffd38` | fix: keep encrypted config out of logs, cache, and plaintext ACK |
| `57c222ba` | fix: fallback to local config cache after first pull miss |
| `890802db` | feat: persist encrypted config as ciphertext and redact logs |

相对本地 `origin/main`（`21dee24b`）还会带上已合入的 #722，以及若干发布流水线 chore（`central-publishing-maven-plugin` / GPG）。若上游 `main` 已含这些提交，GitHub 上的 PR diff 从 `890802db` 起即为本需求。

---

## Summary

- 加密配置**仅在内存中为明文**；本地缓存落盘密文 + Base64 AES `dataKey`（POSIX `0600`），重启后可解密恢复。
- SDK 日志与 `toString` 不再输出配置正文；YAML 解析失败也不把 SnakeYAML snippet 打进 ERROR。
- 明文生效 ACK **只省略加密来源的 `effective_value`**；`conflicts[].value` 原样保留（控制台要展示各来源文件的 file_value）。env / 命令行等 `SourceKind.EXTERNAL` 覆盖照常回传。
- 冷启动首次拉取失败且磁盘缓存命中时立即回落，避免 Spring config-data 被 1/2/4s 重试拖死；3s 后后台补拉一次远端。

## 背景与动机

配置加密开启后，过滤器把服务端密文解到内存。此前本地缓存、日志、`toString`、生效查询 ACK 仍可能带上解密明文。

约束：

1. **未开启加密：行为不变**（`toString` / 部分 DEBUG 不再打正文，属于日志降噪）。
2. **开启加密：只有内存是明文；日志和缓存看不到明文。**
3. **配置生效查询信封不变**；加密文件的 `properties` 仍整段 AES；明文文件按来源脱敏，不误伤外部覆盖和冲突展示。

`RSAService` 每进程重新生成 RSA 密钥对且不落盘，服务端包裹密钥重启后解不开。要保留加密配置的缓存降级，只能把明文 AES 密钥与密文同文件存放，按凭据文件用 `0600` 保护。

## 工作原理

```
远端拉取 ──过滤器解密──► 内存 ConfigFile（content=明文, sourceContent=密文, dataKey=明文 AES）
                              │
                              ├─ 业务 / Spring：读明文
                              ├─ copyForPersist：content=密文, cacheEncrypted=true, 权限 0600
                              ├─ 日志 / toString：只打坐标与变更类型
                              └─ ACK getSnapshot()：content=源密文
                                    加密文件 → properties 整段 AES（需 isAckCryptoAvailable）
                                    明文文件 → 只按 SourceKind 决定是否省略 effective_value
```

### 缓存

- 落盘判据：`sourceContent` 非空（解密成功），不用请求侧 `encrypted`（过滤器会提前声明能力）。
- `sourceContent` 非空但缺 `dataKey`：`copyForPersist` 返回 null，**进重试循环之前就放弃**，不写明文。
- 读到升级前「`encrypted=true` 但 content 是明文」的遗留缓存：丢弃并删除文件。
- 权限：写入内容前对 tmp 设 `rw-------`，`ATOMIC_MOVE` 保留 inode，最终文件同样 `0600`。非 POSIX 静默跳过。

### 冷启动回落

内存为空时第一次远端失败即读磁盘缓存，跳过剩余指数退避。命中后 `CATCH_UP_PULL_DELAY_SECONDS=3` 后台 `doPull(1)` 一次（不退避、每文件最多一次），避免占死共用单线程拉取器；失败交给长轮询。

### 明文 ACK 脱敏

SCT **不传加密布尔**。传 `EffectiveValue.sourceFile` + `SourceKind`。SDK 用 `watchRegistry` 快照的 `isEncrypted()` 判定。

| SourceKind | 含义 | `effective_value` |
|---|---|---|
| `POLARIS_FILE` | 来源是 polaris 文件，须带坐标 | 仅该文件已监听且 `isEncrypted()` 时省略 |
| `EXTERNAL` | env / 命令行 / 系统属性 | **始终保留** |
| `UNKNOWN` | 旧采集侧三参构造，或 `POLARIS_FILE` 却没给坐标（构造器降级） | 有加密监听文件且 `file_value ≠ effective_value` 时省略 |

**`conflicts[].value` 一律保留**，包括来自加密文件的冲突值。控制台冲突展示需要的是各文件的 `file_value`，不是运行时生效值。

加密文件 ACK：仅当 `encryptAlgo` 非空且 BouncyCastle 在位（`isAckCryptoAvailable`）才 RSA 封装 `data_key`、AES 加密 properties；否则省略字段，不把整包 ACK 打成 `internal_error`。

### 给 SCT 的加密标记

api 层 `ConfigFile.isEncrypted()`（default `false`）。`RemoteConfigFileRepo` 取**响应侧**对象；`CompositeConfigFile` 为任一子文件加密即 true。供 SCT 首次加载按文件脱敏日志。

## 改动清单

| 模块 | 改动 | 公开 API |
|------|------|----------|
| `polaris-configuration-api` | `isEncrypted()` default；`EffectiveValue` 增加 `sourceFile` / `SourceKind` 与五参构造（三/四参兼容）；ChangeEvent / PropertyChangeInfo 的 `toString` 去掉正文 | 是，向后兼容 |
| `polaris-configuration-client` | 密文落盘、`0600`、拒写明文、丢弃遗留明文缓存；日志脱敏；first-miss + 补拉；ACK 按 `SourceKind` 省略 `effective_value` | 否 |
| `polaris-plugin-api` | `ConfigFile.toString` 去掉 content | 仅 toString |
| `connector-polaris-grpc` | PUSH/ACK 日志只打 `contentLength` | 否 |

## 影响面

- **未加密**：业务取值与落盘不变。
- **加密缓存**：多 `cacheEncrypted`；旧明文缓存加载即丢弃。回退到旧 SDK 会把密文当明文，回退前清 persist 目录或关 `fallbackToLocalCache`。
- **ACK 信封不变**。相对旧行为：加密来源可能没有 `effective_value`；`conflicts[].value` **有**（含加密文件）；SCT 填 `EXTERNAL` 后 env/sysprop 的 `effective_value` **有**。
- **SCT 必须后合**：五参构造 + api `isEncrypted()`。联调需重装 `polaris-all`，只装 api 模块不生效。回滚：先 SCT 再 polaris-java。

未监听的 polaris 来源：`isEncryptedWatchedFile` 查不到快照视为非加密，`effective_value` 会保留（`testEffectiveValueKeptWhenSourceFileNotWatched`）。采集侧应只对已监听文件填 `POLARIS_FILE`。

## Test plan

```bash
mvn test -pl polaris-configuration/polaris-configuration-client -am -DfailIfNoTests=false
```

- [ ] 密文落盘 + `cacheEncrypted=true` + POSIX `0600`
- [ ] 缺 `dataKey` 不落盘；遗留明文缓存加载 null 并删文件
- [ ] 未加密 round-trip 不变
- [ ] 日志 / toString 无明文、密文、dataKey；YAML 解析 ERROR 无 snippet
- [ ] first-miss 只拉一次远端；补拉一次能收敛；补拉失败不重复读盘覆盖内存
- [ ] ACK：`testConflictValueFromEncryptedFileIsKept`；加密来源省略 `effective_value`；`EXTERNAL` 保留；`POLARIS_FILE` 缺坐标 fail-closed；加密文件 properties 为密文字符串

## 回滚策略

- 回退本分支。未加密客户端不受缓存格式影响。
- 密文缓存 + 旧 SDK：清 persist 或 `fallbackToLocalCache: false`。
- 关生效查询：`reportClientRequestCustomizer.plugin.config-effective.enable: false`。

## 检查清单

- [x] Conventional Commits + `Signed-off-by`（DCO）+ `Co-Authored-By`
- [x] 未使用 Java 8 以上 API
- [x] 未手工编辑 `.flattened-pom.xml`
- [x] 旧采集侧三参构造仍可编译（UNKNOWN）
- [x] 已 push 到 `origin/feat/sensitive-data-encryption`
- [ ] Checkstyle（聚合 pom 上 `checkstyle:check` 既有 `this.file is null`）
- [ ] 开 PR 前确认上游 `main` 是否已含 #722 / 发布流水线 chore，避免无关 diff
